### PR TITLE
Re-enable node-controller for ccm

### DIFF
--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	sdkconfig "github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,7 @@ const (
 
 type CloudControllerManager struct {
 	loadBalancer *LoadBalancer
+	instances    *Instances
 }
 
 // Config is used to read and store information from the cloud configuration file
@@ -151,6 +153,21 @@ func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudCont
 		return nil, err
 	}
 
+	iaasInnerClient, err := iaas.NewAPIClient(
+		sdkconfig.WithRegion(cfg.Region),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create IaaS client: %v", err)
+	}
+	nodeClient, err := stackit.NewNodeClient(iaasInnerClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Node client: %v", err)
+	}
+	instances, err := NewInstance(nodeClient, cfg.ProjectID, cfg.Region)
+	if err != nil {
+		return nil, err
+	}
+
 	lb, err := NewLoadBalancer(client, cfg.ProjectID, cfg.NetworkID, cfg.ExtraLabels, obs)
 	if err != nil {
 		return nil, err
@@ -158,6 +175,7 @@ func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudCont
 
 	ccm := CloudControllerManager{
 		loadBalancer: lb,
+		instances:    instances,
 	}
 	return &ccm, nil
 }
@@ -172,7 +190,7 @@ func (ccm *CloudControllerManager) Initialize(clientBuilder cloudprovider.Contro
 }
 
 func (ccm *CloudControllerManager) InstancesV2() (cloudprovider.InstancesV2, bool) {
-	return nil, true
+	return ccm.instances, true
 }
 
 func (ccm *CloudControllerManager) LoadBalancer() (cloudprovider.LoadBalancer, bool) {


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/hold Requires new STACKIT SDK that supports IaaS API v2

**What this PR does / why we need it**:

Re-initialize the node-controller by default. The IaaS v1 SDK can now handle multiple regions.
Previously the setup would fail in `eu02` as the SDK did not support different regions yet.

**Related work items**:

STACKITSKE-100

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
