### PR TITLE
Add make variable IS_DEV to control oci image suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ BUILD_IMAGES ?= stackit-csi-plugin cloud-controller-manager
 SOURCES := Makefile go.mod go.sum $(shell find $(DEST) -name '*.go' 2>/dev/null)
 VERSION ?= $(shell git describe --dirty --tags --match='v*')
 REGISTRY ?= ghcr.io
-REPO ?= stackitcloud/cloud-provider-stackit-dev
+REPO ?= stackitcloud/cloud-provider-stackit
 PLATFORMS ?= amd64 arm64
+IS_DEV ?= true
 
 .PHONY: all
 all: verify
@@ -42,6 +43,7 @@ image-%: $(APKO) $(KO)
 	PLATFORMS="$(PLATFORMS)" \
 	REGISTRY=$(REGISTRY) \
 	REPO=$(REPO)/$* \
+	IS_DEV=$(IS_DEV) \
 	./hack/build.sh $*
 
 .PHONY: clean-tools-bin

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 BUILD_IMAGES ?= stackit-csi-plugin cloud-controller-manager
 SOURCES := Makefile go.mod go.sum $(shell find $(DEST) -name '*.go' 2>/dev/null)
-VERSION ?= $(shell git describe --dirty --tags --match='v*')
+VERSION ?= $(shell git describe --dirty --tags --match='v*' 2>/dev/null || git rev-parse --short HEAD)
 REGISTRY ?= ghcr.io
 REPO ?= stackitcloud/cloud-provider-stackit
 PLATFORMS ?= amd64 arm64

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -49,6 +49,9 @@ if git_tag="$(git describe --tags --exact-match 2>/dev/null)"; then
   tags+=("$git_tag")
 fi
 
+if [[ ${IS_DEV} == "true" ]]; then
+  REPO=${REPO}-dev
+fi
 BASE_IMAGE=${REGISTRY}/${REPO}-base
 platforms=(${PLATFORMS})
 if [[ -f cmd/$IMAGE/apko-base-image.yaml ]]; then

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -19,7 +19,7 @@ if [[ -z ${LOCAL} ]]; then
   LOCAL="false"
 fi
 
-function comma_seperated() {
+function comma_separated() {
   local arr=("$@")
   local IFS=,
   echo "${arr[*]}"
@@ -35,9 +35,9 @@ fi
 # generate a tag that renovate can easily compare (similar to prow's image tags)
 # format: v<commit-timestamp>-<short-commit-sha>
 tags=(
-  "v$(date -d @$(git show -s --format=%ct @) -u +%Y%m%d%H%M%S)-$(git rev-parse HEAD | head -c7)"
-  ${VERSION}
-  $(echo ${PULL_BASE_REF} | sed 's/\//_/g' | sed 's/#//g')
+  "v$(date -d @"$(git show -s --format=%ct @)" -u +%Y%m%d%H%M%S)-$(git rev-parse HEAD | head -c7)"
+  "${VERSION}"
+  "$(echo "${PULL_BASE_REF}" | sed 's/\//_/g' | sed 's/#//g')"
 )
 
 if [[ -n "${PULL_NUMBER:=""}" ]]; then
@@ -53,20 +53,20 @@ if [[ ${IS_DEV} == "true" ]]; then
   REPO=${REPO}-dev
 fi
 BASE_IMAGE=${REGISTRY}/${REPO}-base
-platforms=(${PLATFORMS})
+IFS=' ' read -r -a platforms <<< "${PLATFORMS}"
 if [[ -f cmd/$IMAGE/apko-base-image.yaml ]]; then
   if [[ ${LOCAL} == "true" ]]; then
     BASE_IMAGE=ko.local/${IMAGE}-base
-    platforms=($(uname -m))
+    mapfile -t platforms < <(uname -m)
   fi
 
-  APKO_IMAGE=$(apko publish --local=${LOCAL} cmd/${IMAGE}/apko-base-image.yaml ${BASE_IMAGE} --sbom=false -p "${APKO_EXTRA_PACKAGES}" --arch $(comma_seperated "${platforms[@]}"))
+  APKO_IMAGE=$(apko publish --local="${LOCAL}" "cmd/${IMAGE}/apko-base-image.yaml" "${BASE_IMAGE}" --sbom=false -p "${APKO_EXTRA_PACKAGES}" --arch "$(comma_separated "${platforms[@]}")")
   export KO_DEFAULTBASEIMAGE=${APKO_IMAGE}
   if [[ ${LOCAL} == "true" ]]; then
     # apko only published images to registry apko.local with repo cache when running in local mode.
     # Need to tag to registry ko.local for ko to see that the image needs to be resolved locally
     # will be fixed in https://github.com/chainguard-dev/apko/pull/1781
-    docker tag ${APKO_IMAGE} ${BASE_IMAGE}
+    docker tag "${APKO_IMAGE}" "${BASE_IMAGE}"
     export KO_DEFAULTBASEIMAGE=${BASE_IMAGE}
   fi
 fi
@@ -79,16 +79,16 @@ done
 
 labels=(
   org.opencontainers.image.created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  org.opencontainers.image.revision=${VERSION}
+  org.opencontainers.image.revision="${VERSION}"
   org.opencontainers.image.source=https://github.com/stackitcloud/cloud-provider-stackit
   org.opencontainers.image.url=https://github.com/stackitcloud/cloud-provider-stackit
 )
 
 KO_DOCKER_REPO=${REGISTRY}/${REPO} \
-  ko build --local=${LOCAL} \
-  -t $(comma_seperated "${tags[@]}") \
+  ko build --local="${LOCAL}" \
+  -t "$(comma_separated "${tags[@]}")" \
   --sbom=none \
-  --platform $(comma_seperated "${ko_platforms[@]}") \
+  --platform "$(comma_separated "${ko_platforms[@]}")" \
   --bare \
-  --image-label=$(comma_seperated "${labels[@]}") \
-  ./cmd/$IMAGE
+  --image-label="$(comma_separated "${labels[@]}")" \
+  "./cmd/$IMAGE"


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

If set, container images will be named `*-dev`

- `ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager-dev`
- `ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin-dev`

**Related work items**:

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
