### PR TITLE
Drop CSI with-topology and cleanups

### DIFF
--- a/cmd/stackit-csi-plugin/main.go
+++ b/cmd/stackit-csi-plugin/main.go
@@ -25,7 +25,6 @@ var (
 	httpEndpoint             string
 	provideControllerService bool
 	provideNodeService       bool
-	withTopology             bool
 )
 
 func main() {
@@ -65,8 +64,6 @@ func main() {
 
 	cmd.Flags().StringVar(&cloudConfig, "cloud-config", "", "CSI driver cloud config. This option can be given multiple times")
 
-	cmd.PersistentFlags().BoolVar(&withTopology, "with-topology", true, "cluster is topology-aware")
-
 	cmd.PersistentFlags().StringToStringVar(&additionalTopologies, "additional-topology", map[string]string{},
 		"Additional CSI driver topology keys, for example topology.kubernetes.io/region=REGION1."+
 			"This option can be specified multiple times to add multiple additional topology keys.")
@@ -90,20 +87,19 @@ func main() {
 func handle() {
 	// Initialize cloud
 	d := blockstorage.NewDriver(&blockstorage.DriverOpts{
-		Endpoint:     endpoint,
-		ClusterID:    cluster,
-		PVCLister:    csi.GetPVCLister(),
-		WithTopology: withTopology,
+		Endpoint:  endpoint,
+		ClusterID: cluster,
+		PVCLister: csi.GetPVCLister(),
 	})
 
 	if provideControllerService {
 		var err error
-		cfg, err := stackit.GetConfigForFile(cloudConfig)
+		cfg, err := stackit.GetConfigFromFile(cloudConfig)
 		if err != nil {
 			klog.Fatal(err)
 		}
 
-		iaasClient, err := stackit.CreateIAASClient(&cfg)
+		iaasClient, err := stackit.CreateIaaSClient(&cfg)
 		if err != nil {
 			klog.Fatalf("Failed to create IaaS client: %v", err)
 		}
@@ -120,7 +116,7 @@ func handle() {
 		// Initialize mount
 		mountProvider := mount.GetMountProvider()
 
-		cfg, err := stackit.GetConfigForFile(cloudConfig)
+		cfg, err := stackit.GetConfigFromFile(cloudConfig)
 		if err != nil {
 			klog.Fatal(err)
 		}

--- a/cmd/stackit-csi-plugin/main.go
+++ b/cmd/stackit-csi-plugin/main.go
@@ -20,7 +20,6 @@ import (
 var (
 	endpoint                 string
 	cloudConfig              string
-	additionalTopologies     map[string]string
 	cluster                  string
 	httpEndpoint             string
 	provideControllerService bool
@@ -63,10 +62,6 @@ func main() {
 	}
 
 	cmd.Flags().StringVar(&cloudConfig, "cloud-config", "", "CSI driver cloud config. This option can be given multiple times")
-
-	cmd.PersistentFlags().StringToStringVar(&additionalTopologies, "additional-topology", map[string]string{},
-		"Additional CSI driver topology keys, for example topology.kubernetes.io/region=REGION1."+
-			"This option can be specified multiple times to add multiple additional topology keys.")
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
 	cmd.PersistentFlags().StringVar(&httpEndpoint, "http-endpoint", "",
@@ -124,7 +119,7 @@ func handle() {
 		// Initialize Metadata
 		metadataProvider := metadata.GetMetadataProvider(fmt.Sprintf("%s,%s", metadata.MetadataID, metadata.ConfigDriveID))
 
-		d.SetupNodeService(mountProvider, metadataProvider, cfg.BlockStorage, additionalTopologies)
+		d.SetupNodeService(mountProvider, metadataProvider, cfg.BlockStorage)
 	}
 
 	d.Run()

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: stackit-cloud-controller-manager
-        image: ghcr.io/stackitcloud/cloud-provider-stackit:latest
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.33
         args:
         - --cloud-provider=stackit
         - --webhook-secure-port=0

--- a/docs/csi-driver.md
+++ b/docs/csi-driver.md
@@ -89,7 +89,7 @@ storageClass:
   volumeBindingMode: WaitForFirstConsumer
   allowedTopologies:
     - matchLabelExpressions:
-        - key: topology.kubernetes.io/zone
+        - key: topology.block-storage.csi.stackit.cloud/zone
           values:
             - zone1
             - zone2

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,7 +11,6 @@
 5. [Example Deployment](#example-deployment)
 6. [Configuration Options](#configuration-options)
    - [Cloud Configuration](#cloud-configuration)
-   - [Topology Configuration](#topology-configuration)
 7. [Monitoring and Logging](#monitoring-and-logging)
    - [Metrics](#metrics)
    - [Logs](#logs)
@@ -46,7 +45,6 @@ The deployment can be customized using the following flags:
 
 - `--endpoint`: CSI endpoint URL
 - `--cloud-config`: Path to cloud configuration file
-- `--additional-topology`: Additional topology keys for volume placement
 - `--cluster`: Cluster identifier
 - `--http-endpoint`: HTTP server endpoint for metrics
 - `--provide-controller-service`: Enable controller service (default: true)
@@ -96,7 +94,6 @@ spec:
         # CSI flags
         - --endpoint=unix:///csi/csi.sock
         - --cloud-config=/etc/stackit/cloud-config.yaml
-        - --additional-topology=topology.kubernetes.io/region=REGION1
         - --cluster=my-cluster-id
         - --provide-controller-service=true
         - --provide-node-service=true
@@ -133,16 +130,6 @@ networkId: your-network-id
 region: eu01
 loadBalancerApi:
   url: https://load-balancer.api.eu01.stackit.cloud
-```
-
-### Topology Configuration
-
-The driver supports topology-aware volume placement. Configure topology using and `--additional-topology` flags.
-
-Example with multiple topology keys:
-
-```bash
---additional-topology=topology.kubernetes.io/region=REGION1,topology.kubernetes.io/zone=ZONE1
 ```
 
 ## Monitoring and Logging

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,7 +46,6 @@ The deployment can be customized using the following flags:
 
 - `--endpoint`: CSI endpoint URL
 - `--cloud-config`: Path to cloud configuration file
-- `--with-topology`: Enable topology awareness (default: true)
 - `--additional-topology`: Additional topology keys for volume placement
 - `--cluster`: Cluster identifier
 - `--http-endpoint`: HTTP server endpoint for metrics
@@ -84,7 +83,7 @@ spec:
       serviceAccountName: stackit-cloud-controller-manager
       containers:
       - name: stackit-cloud-controller-manager
-        image: ghcr.io/stackitcloud/cloud-provider-stackit:latest
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.33
         args:
         # CCM flags
         - --cloud-provider=stackit
@@ -97,7 +96,6 @@ spec:
         # CSI flags
         - --endpoint=unix:///csi/csi.sock
         - --cloud-config=/etc/stackit/cloud-config.yaml
-        - --with-topology=true
         - --additional-topology=topology.kubernetes.io/region=REGION1
         - --cluster=my-cluster-id
         - --provide-controller-service=true
@@ -139,12 +137,11 @@ loadBalancerApi:
 
 ### Topology Configuration
 
-The driver supports topology-aware volume placement. Configure topology using the `--with-topology` and `--additional-topology` flags.
+The driver supports topology-aware volume placement. Configure topology using and `--additional-topology` flags.
 
 Example with multiple topology keys:
 
 ```bash
---with-topology=true
 --additional-topology=topology.kubernetes.io/region=REGION1,topology.kubernetes.io/zone=ZONE1
 ```
 

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -3,27 +3,29 @@
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 
 color-green() { # Green
-  echo -e "\x1B[1;32m${@}\x1B[0m"
+  echo -e "\x1B[1;32m${*}\x1B[0m"
 }
 
 color-step() { # Yellow
-  echo -e "\x1B[1;33m${@}\x1B[0m"
+  echo -e "\x1B[1;33m${*}\x1B[0m"
 }
 
 color-context() { # Bold blue
-  echo -e "\x1B[1;34m${@}\x1B[0m"
+  echo -e "\x1B[1;34m${*}\x1B[0m"
 }
 
 color-missing() { # Yellow
-  echo -e "\x1B[1;33m${@}\x1B[0m"
+  echo -e "\x1B[1;33m${*}\x1B[0m"
 }
 
 prepare_token() {
   local namespace="$1"
   local name="$2"
-  local rolekind="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
   local role="$4"
   local duration="${5:-10m}"
+
+  local rolekind
+  rolekind="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
 
   result="$(kubectl -n "$namespace" create serviceaccount "$name" 2>&1)"
   # ignore "already exists" errors
@@ -44,9 +46,11 @@ prepare_token() {
 prepare_access() {
   local namespace="$1"
   local name="$2"
-  local rolekind="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
   local role="$4"
   local tmp_kubeconfig="$5"
+
+  local rolekind
+  rolekind="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
 
   color-step "Preparing access for $name"
 
@@ -71,9 +75,11 @@ prepare_access() {
 cleanup_access() {
   local namespace="$1"
   local name="$2"
-  local rolekind="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
   local role="$4"
   local tmp_kubeconfig="$5"
+
+  local rolekind
+  rolekind="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
 
   color-step "Cleaning up cluster access for $name"
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -4,22 +4,24 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# shellcheck disable=SC1091
 source "$(dirname "$0")/common.sh"
 
 echo "> Unit Tests"
 
-test_flags=
+test_flags=()
 # If running in Prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" ] && [ -n "${ARTIFACTS:-}" ]; then
   mkdir -p "$ARTIFACTS/junit"
+  # shellcheck disable=SC2064
   trap "collect_reports \"$ARTIFACTS/junit\"" EXIT
-  test_flags="--ginkgo.junit-report=junit.xml"
+  test_flags+=(--ginkgo.junit-report=junit.xml)
   # Use Ginkgo timeout in Prow to print everything that is buffered in GinkgoWriter.
-  test_flags+=" --ginkgo.timeout=2m"
+  test_flags+=(--ginkgo.timeout=2m)
 else
   # We don't want Ginkgo's timeout flag locally because it causes skipping the test cache.
   timeout_flag="-timeout=2m"
 fi
 
-go test ${timeout_flag:-} "$@" $test_flags
+go test "${timeout_flag:-}" "$@" "${test_flags[@]}"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -24,4 +24,4 @@ else
   timeout_flag="-timeout=2m"
 fi
 
-go test "${timeout_flag:-}" "$@" "${test_flags[@]}"
+go test ${timeout_flag:+"$timeout_flag"} "$@" "${test_flags[@]}"

--- a/pkg/csi/blockstorage/controllerserver.go
+++ b/pkg/csi/blockstorage/controllerserver.go
@@ -105,16 +105,14 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volSizeGB := util.RoundUpSize(volSizeBytes, util.GIBIBYTE)
 
 	var volAvailability string
-	if cs.Driver.withTopology {
-		// First check if volAvailability is already specified, if not get preferred from Topology
-		// Required, incase vol AZ is different from node AZ
-		volAvailability = ptr.Deref(volParams.AvailabilityZone, "")
-		if volAvailability == "" {
-			accessibleTopologyReq := req.GetAccessibilityRequirements()
-			// Check from Topology
-			if accessibleTopologyReq != nil {
-				volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
-			}
+	// First check if volAvailability is already specified, if not get preferred from Topology
+	// Required, incase vol AZ is different from node AZ
+	volAvailability = ptr.Deref(volParams.AvailabilityZone, "")
+	if volAvailability == "" {
+		accessibleTopologyReq := req.GetAccessibilityRequirements()
+		// Check from Topology
+		if accessibleTopologyReq != nil {
+			volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
 		}
 	}
 

--- a/pkg/csi/blockstorage/controllerserver.go
+++ b/pkg/csi/blockstorage/controllerserver.go
@@ -105,12 +105,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volSizeGB := util.RoundUpSize(volSizeBytes, util.GIBIBYTE)
 
 	var volAvailability string
-	// First check if volAvailability is already specified, if not get preferred from Topology
-	// Required, incase vol AZ is different from node AZ
+	// First check if volAvailability is already specified, if not, get preferred from topology
+	// Required, in case volume AZ is different from node AZ
 	volAvailability = ptr.Deref(volParams.AvailabilityZone, "")
 	if volAvailability == "" {
 		accessibleTopologyReq := req.GetAccessibilityRequirements()
-		// Check from Topology
+		// Check from topology
 		if accessibleTopologyReq != nil {
 			volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
 		}

--- a/pkg/csi/blockstorage/controllerserver_test.go
+++ b/pkg/csi/blockstorage/controllerserver_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ControllerServer test", Ordered, func() {
 	)
 
 	BeforeEach(func() {
-		d := NewDriver(&DriverOpts{Endpoint: FakeEndpoint, ClusterID: FakeCluster, WithTopology: true})
+		d := NewDriver(&DriverOpts{Endpoint: FakeEndpoint, ClusterID: FakeCluster})
 
 		mockCtrl := gomock.NewController(GinkgoT())
 		iaasClient = stackit.NewMockIaasClient(mockCtrl)

--- a/pkg/csi/blockstorage/driver.go
+++ b/pkg/csi/blockstorage/driver.go
@@ -138,9 +138,9 @@ func (d *Driver) SetupControllerService(instance stackit.IaasClient) {
 	d.cs = NewControllerServer(d, instance)
 }
 
-func (d *Driver) SetupNodeService(mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackit.BlockStorageOpts, topologies map[string]string) {
+func (d *Driver) SetupNodeService(mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackit.BlockStorageOpts) {
 	klog.Info("Providing node service")
-	d.ns = NewNodeServer(d, mountProvider, metadataProvider, opts, topologies)
+	d.ns = NewNodeServer(d, mountProvider, metadataProvider, opts)
 }
 
 func (d *Driver) Run() {

--- a/pkg/csi/blockstorage/driver.go
+++ b/pkg/csi/blockstorage/driver.go
@@ -28,11 +28,10 @@ var (
 )
 
 type Driver struct {
-	name         string
-	fqVersion    string // Fully qualified version in format {Version}@{CPO version}
-	endpoint     string
-	clusterID    string
-	withTopology bool
+	name      string
+	fqVersion string // Fully qualified version in format {Version}@{CPO version}
+	endpoint  string
+	clusterID string
 
 	ids *identityServer
 	cs  *controllerServer
@@ -47,27 +46,24 @@ type Driver struct {
 }
 
 type DriverOpts struct {
-	ClusterID    string
-	Endpoint     string
-	WithTopology bool
+	ClusterID string
+	Endpoint  string
 
 	PVCLister corev1.PersistentVolumeClaimLister
 }
 
 func NewDriver(o *DriverOpts) *Driver {
 	d := &Driver{
-		name:         driverName,
-		fqVersion:    fmt.Sprintf("%s@%s", Version, version.Version),
-		endpoint:     o.Endpoint,
-		clusterID:    o.ClusterID,
-		withTopology: o.WithTopology,
-		pvcLister:    o.PVCLister,
+		name:      driverName,
+		fqVersion: fmt.Sprintf("%s@%s", Version, version.Version),
+		endpoint:  o.Endpoint,
+		clusterID: o.ClusterID,
+		pvcLister: o.PVCLister,
 	}
 
 	klog.Info("Driver: ", d.name)
 	klog.Info("Driver version: ", d.fqVersion)
 	klog.Info("CSI Spec version: ", specVersion)
-	klog.Infof("Topology awareness: %t", d.withTopology)
 
 	d.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -40,11 +40,10 @@ import (
 )
 
 type nodeServer struct {
-	Driver     *Driver
-	Mount      mount.IMount
-	Metadata   metadata.IMetadata
-	Opts       stackit.BlockStorageOpts
-	Topologies map[string]string
+	Driver   *Driver
+	Mount    mount.IMount
+	Metadata metadata.IMetadata
+	Opts     stackit.BlockStorageOpts
 	csi.UnimplementedNodeServer
 }
 
@@ -322,12 +321,13 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "[NodeGetInfo] Unable to retrieve availability zone of node %v", err)
 	}
-	topologyMap := make(map[string]string, len(ns.Topologies)+1)
-	topologyMap[topologyKey] = zone
-	for k, v := range ns.Topologies {
-		topologyMap[k] = v
+
+	//TODO: support well-known topology key "topology.kubernetes.io/zone"
+	segments := map[string]string{
+		topologyKey: zone,
 	}
-	nodeInfo.AccessibleTopology = &csi.Topology{Segments: topologyMap}
+
+	nodeInfo.AccessibleTopology = &csi.Topology{Segments: segments}
 
 	return nodeInfo, nil
 }

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -318,10 +318,6 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 		MaxVolumesPerNode: maxVolumesPerNode,
 	}
 
-	if !ns.Driver.withTopology {
-		return nodeInfo, nil
-	}
-
 	zone, err := ns.Metadata.GetAvailabilityZone(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "[NodeGetInfo] Unable to retrieve availability zone of node %v", err)

--- a/pkg/csi/blockstorage/nodeserver_test.go
+++ b/pkg/csi/blockstorage/nodeserver_test.go
@@ -28,7 +28,7 @@ var _ = Describe("NodeServer", func() {
 	)
 
 	BeforeEach(func() {
-		d := NewDriver(&DriverOpts{Endpoint: fakeEndpoint, ClusterID: fakeCluster, WithTopology: true})
+		d := NewDriver(&DriverOpts{Endpoint: fakeEndpoint, ClusterID: fakeCluster})
 
 		ctrl := gomock.NewController(GinkgoT())
 

--- a/pkg/csi/blockstorage/nodeserver_test.go
+++ b/pkg/csi/blockstorage/nodeserver_test.go
@@ -43,7 +43,6 @@ var _ = Describe("NodeServer", func() {
 			mountMock,
 			metadataMock,
 			stackit.BlockStorageOpts{},
-			map[string]string{}, // topologies
 		)
 	})
 

--- a/pkg/csi/blockstorage/utils.go
+++ b/pkg/csi/blockstorage/utils.go
@@ -56,13 +56,12 @@ func NewIdentityServer(d *Driver) *identityServer {
 	}
 }
 
-func NewNodeServer(d *Driver, mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackit.BlockStorageOpts, topologies map[string]string) *nodeServer { //nolint:lll // looks weird when shortened
+func NewNodeServer(d *Driver, mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackit.BlockStorageOpts) *nodeServer { //nolint:lll // looks weird when shortened
 	return &nodeServer{
-		Driver:     d,
-		Mount:      mountProvider,
-		Metadata:   metadataProvider,
-		Topologies: topologies,
-		Opts:       opts,
+		Driver:   d,
+		Mount:    mountProvider,
+		Metadata: metadataProvider,
+		Opts:     opts,
 	}
 }
 

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -138,7 +138,7 @@ type Config struct {
 	BlockStorage BlockStorageOpts
 }
 
-func GetConfigForFile(path string) (Config, error) {
+func GetConfigFromFile(path string) (Config, error) {
 	var cfg Config
 
 	config, err := os.Open(path)
@@ -173,7 +173,7 @@ func CreateSTACKITProvider(client iaas.DefaultApi, cfg *Config) (IaasClient, err
 	return instance, nil
 }
 
-func CreateIAASClient(cfg *Config) (iaas.DefaultApi, error) {
+func CreateIaaSClient(cfg *Config) (iaas.DefaultApi, error) {
 	var userAgent []string
 	var opts []sdkconfig.ConfigurationOption
 	userAgent = append(userAgent, fmt.Sprintf("%s/%s", "block-storage-csi-driver", version.Version))

--- a/pkg/stackit/snapshots.go
+++ b/pkg/stackit/snapshots.go
@@ -21,8 +21,6 @@ const (
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
 
-	snapshotDescription = "Created by STACKIT CSI driver" //nolint:unused // needs implementation, don't remove it
-
 	SnapshotType             = "type"
 	SnapshotAvailabilityZone = "availability"
 )

--- a/pkg/stackit/snapshots.go
+++ b/pkg/stackit/snapshots.go
@@ -21,7 +21,6 @@ const (
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
 
-	snapshotDescription      = "Created by STACKIT CSI driver"
 	SnapshotType             = "type"
 	SnapshotAvailabilityZone = "availability"
 )

--- a/pkg/stackit/snapshots.go
+++ b/pkg/stackit/snapshots.go
@@ -22,6 +22,7 @@ const (
 	snapReadySteps      = 10
 
 	//TODO: needs implementation, don't remove it
+	//nolint:unused
 	snapshotDescription = "Created by STACKIT CSI driver"
 
 	SnapshotType             = "type"

--- a/pkg/stackit/snapshots.go
+++ b/pkg/stackit/snapshots.go
@@ -21,9 +21,7 @@ const (
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
 
-	//TODO: needs implementation, don't remove it
-	//nolint:unused
-	snapshotDescription = "Created by STACKIT CSI driver"
+	snapshotDescription = "Created by STACKIT CSI driver" //nolint:unused // needs implementation, don't remove it
 
 	SnapshotType             = "type"
 	SnapshotAvailabilityZone = "availability"

--- a/pkg/stackit/snapshots.go
+++ b/pkg/stackit/snapshots.go
@@ -21,6 +21,9 @@ const (
 	snapReadyFactor     = 1.2
 	snapReadySteps      = 10
 
+	//TODO: needs implementation, don't remove it
+	snapshotDescription = "Created by STACKIT CSI driver"
+
 	SnapshotType             = "type"
 	SnapshotAvailabilityZone = "availability"
 )


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

- Drop CSI flag `with-topology`, topology support is always enabled now and no need to disable it
- Improve some method names
- Cleanup docs 

**Related work items**:

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
