### PR TITLE
LoadBalancer: support class from annotation

### DIFF
--- a/deploy/cm.yaml
+++ b/deploy/cm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stackit-cloud-controller-manager
+data:
+  cloud-config.yaml: |
+    projectId: "<PROJECT_ID>"
+    networkId" "<NETWORK_ID>"
+    region: eu01
+    # extraLabels: 
+    #   key: value
+    # loadBalancerApi:
+    #   url: ""
+    # loadbalancer:
+    #   class: "my-class"

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         - --authorization-always-allow-paths=/metrics
         - --leader-elect=true
         - --leader-elect-resource-name=stackit-cloud-controller-manager
-        # - --cloud-config=cloud-config.yaml
-        # - --cluster-name=<cluster-id>
+        - --cloud-config=/config/cloud-config.yaml
+        - --cluster-name=stackit-cluster
         ports:
           - containerPort: 10258
             hostPort: 10258
@@ -51,3 +51,10 @@ spec:
           requests:
             cpu: "0.1"
             memory: 100Mi
+        volumeMounts:
+          - mountPath: /config
+            name: cloud-config
+      volumes:
+        - name: cloud-config
+          configMap:
+            name: stackit-cloud-controller-manager

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- cm.yaml
 - rbac.yaml
 - deployment.yaml
 - service.yaml

--- a/docs/load-balancer.md
+++ b/docs/load-balancer.md
@@ -9,7 +9,8 @@
    - [STACKIT Annotations](#stackit-annotations)
    - [Supported yawol Annotations](#supported-yawol-annotations)
    - [Unsupported yawol Annotations](#unsupported-yawol-annotations)
-5. [Node Labels](#node-labels)
+5. [Loadbalancer class](#loadbalancer-class)
+6. [Node Labels](#node-labels)
 
 ## Overview
 
@@ -51,6 +52,8 @@ Values for boolean annotations are parsed according to [ParseBool](https://pkg.g
 | lb.stackit.cloud/session-persistence-with-source-ip | false      | When set to true, all connections from the same source IP are consistently routed to the same target. This setting changes the load balancing algorithm to Maglev. Note, this only works reliably when `externalTrafficPolicy: Local` is set on the Service, and each node has exactly one backing pod. Otherwise, session persistence may break.                                                                        |
 | lb.stackit.cloud/listener-network                   | _none_     | When set, defines the network in which the load balancer should listen. If not set, the SKE network is used for listening. The value must be a network ID, not a subnet. The annotation can neither be changed nor be added or removed after service creation.                                                                                                                                                           |
 
+| lb.stackit.cloud/class-name                   | _none_     | When set, the cloud controller manager will only reconcile the service if it's configured to reconcile this class                                                                                                                                                           |
+
 ### Supported yawol Annotations
 
 To simplify the transition from a yawol load balancer, some yawol annotations are supported on STACKIT load balancers.
@@ -60,7 +63,7 @@ A load balancer contain both annotations as long as their values are compatible.
 | Name                                            | Description                                                                                                                                                                                                                                                                                                                                         |
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | yawol.stackit.cloud/internalLB                  | If true, the load balancer is not exposed via a floating IP. Default is false (i.e. exposed). Deprecated: Use lb.stackit.cloud/internal-lb instead.                                                                                                                                                                                                 |
-| yawol.stackit.cloud/existingFloatingIP          | References an OpenStack floating IP that should be used by the load balancer. If set, it will be used instead of an ephemeral IP. The IP must be created by the user. When the service is deleted, the floating IP will not be deleted. The IP is ignored if the load balancer internal. Deprecated: Use lb.stackit.cloud/external-address instead. |
+| yawol.stackit.cloud/existingFloatingIP          | References an OpenStack floating IP that should be used by the lload balancer. If set, it will be used instead of an ephemeral IP. The IP must be created by the user. When the service is deleted, the floating IP will not be deleted. The IP is ignored if the load balancer internal. Deprecated: Use lb.stackit.cloud/external-address instead. |
 | yawol.stackit.cloud/loadBalancerSourceRanges    | Specify the `loadBalancerSourceRanges` for the load balancer like `service.spec.loadBalancerSourceRanges` (comma separated list). Deprecated: Use `service.spec.loadBalancerSourceRanges` instead.                                                                                                                                                  |
 | yawol.stackit.cloud/tcpProxyProtocol            | Enables the TCP proxy protocol. Deprecated: Use lb.stackit.cloud/tcp-proxy-protocol instead.                                                                                                                                                                                                                                                        |
 | yawol.stackit.cloud/tcpProxyProtocolPortsFilter | Defines which ports should use the TCP proxy protocol. Deprecated: Use lb.stackit.cloud/tcp-proxy-protocol-ports-filter instead.                                                                                                                                                                                                                    |
@@ -87,6 +90,15 @@ They are ignored for provisioning, but an event is logged on the Kubernetes serv
 | yawol.stackit.cloud/logForwardLokiURL                   |       |
 | yawol.stackit.cloud/serverGroupPolicy                   |       |
 | yawol.stackit.cloud/additionalNetworks                  |       |
+
+## Loadbalancer class
+
+To support multiple running cloud controller managers, we support classes via annotatons.
+This can be configured via the config yaml using key `loadbalancer.class`.
+When set, services with the annotation `lb.stackit.cloud/class-name` will be matched against this value to determine if it should reconcile the service.
+
+> [!CAUTION]
+> This does not work with the field `spec.loadbalancerClass` of a service, as this is not usable with the Kubernetes cloud-provider framework.
 
 ## Node Labels
 

--- a/pkg/ccm/loadbalancer_spec.go
+++ b/pkg/ccm/loadbalancer_spec.go
@@ -50,6 +50,9 @@ const (
 	// The value must be a network ID, not a subnet.
 	// The annotation can neither be changed nor be added or removed after service creation.
 	listenerNetworkAnnotation = "lb.stackit.cloud/listener-network"
+
+	// classNameAnnotation defines a loadbalancer class
+	classNameAnnotation = "lb.stackit.cloud/class-name"
 )
 
 const (

--- a/pkg/ccm/loadbalancer_yawol.go
+++ b/pkg/ccm/loadbalancer_yawol.go
@@ -4,13 +4,6 @@ package ccm
 // Some of them are supported by the cloud controller manager to simplify the transition.
 
 const (
-	// yawolClassNameAnnotation defines the load balancer class for the service, and therefore which controller provisions the load balancer.
-	// It must be set to "stackit" for the cloud controller manager to handle this load balancer.
-	// To avoid collisions while being backwards-compatible, yawol handles the service if this annotation is not set.
-	// service.spec.loadBalancerClass is not supported because yawol as well as the cloud controller manager handle the empty class name.
-	// There is no successor for this annotation because both controllers need to understand it.
-	//nolint:unused // Should stay here for documentation purposes
-	yawolClassNameAnnotation = "yawol.stackit.cloud/className"
 	// yawolInternalLBAnnotation defines whether the load balancer should be exposed via a public IP.
 	// Deprecated: use lb.stackit.cloud/internal-lb instead.
 	yawolInternalLBAnnotation = "yawol.stackit.cloud/internalLB"

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -50,6 +50,9 @@ type Config struct {
 	LoadBalancerAPI struct {
 		URL string `yaml:"url"`
 	} `yaml:"loadBalancerApi"`
+	LoadBalancer struct {
+		Class string `yaml:"class"`
+	} `yaml:"loadbalancer"`
 }
 
 func init() {
@@ -168,7 +171,7 @@ func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudCont
 		return nil, err
 	}
 
-	lb, err := NewLoadBalancer(client, cfg.ProjectID, cfg.NetworkID, cfg.ExtraLabels, obs)
+	lb, err := NewLoadBalancer(client, cfg.ProjectID, cfg.NetworkID, cfg.ExtraLabels, obs, cfg.LoadBalancer.Class)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Allows to configure the ccm to only reconcile service with annotation `lb.stackit.cloud/class-name`.

**Related work items**:

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
Signed-off-by: Lukas Hoehl <lukas.hoehl@stackit.cloud>