### PR TITLE
docs: drop legacy config, add extraLabels

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Does not include:
 # cloud-config.yaml
 projectId:
 networkId:
-nonStackitClassNames: # If not set, defaults to "updateAndCreate" (see: Non-STACKIT class names).
 region: eu01
+# extraLabels to add to loadbalancer instances
+extraLabels:
+  key: value
 loadBalancerApi:
   # If not set, defaults to production.
   url: https://load-balancer-dev.api.qa.stackit.cloud


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

Removes the legacy config `nonStackitClassNames` from the config stated in the README. Adds the new `extraLabels` config field to it instead
