### PR TITLE
fix: remove wrong prealloc of nodeAddresses slice

### DIFF
--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -101,9 +101,12 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *corev1.Node) (*c
 		return nil, fmt.Errorf("failed to get instance: %w", err)
 	}
 
-	addresses := make([]corev1.NodeAddress, 0, len(server.GetNics()))
-	for _, v := range server.GetNics() {
-		if ipv4, ok := v.GetIpv4Ok(); ok {
+	var addresses []corev1.NodeAddress
+	if len(server.GetNics()) == 0 {
+		return nil, fmt.Errorf("server has no network interfaces")
+	}
+	for _, nic := range server.GetNics() {
+		if ipv4, ok := nic.GetIpv4Ok(); ok {
 			addToNodeAddresses(&addresses,
 				corev1.NodeAddress{
 					Address: ipv4,
@@ -112,7 +115,7 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *corev1.Node) (*c
 		}
 
 		// TODO: where to find IPv6SupportDisabled
-		if ipv6, ok := v.GetIpv6Ok(); ok {
+		if ipv6, ok := nic.GetIpv6Ok(); ok {
 			addToNodeAddresses(&addresses,
 				corev1.NodeAddress{
 					Address: ipv6,
@@ -120,7 +123,7 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *corev1.Node) (*c
 				})
 		}
 
-		if publicIP, ok := v.GetPublicIpOk(); ok {
+		if publicIP, ok := nic.GetPublicIpOk(); ok {
 			addToNodeAddresses(&addresses,
 				corev1.NodeAddress{
 					Address: publicIP,

--- a/pkg/stackit/server.go
+++ b/pkg/stackit/server.go
@@ -31,7 +31,7 @@ func (cl nodeClient) UpdateServer(ctx context.Context, projectID, region, server
 }
 
 func (cl nodeClient) ListServers(ctx context.Context, projectID, region string) (*[]iaas.Server, error) {
-	resp, err := cl.client.ListServersExecute(ctx, projectID, region)
+	resp, err := cl.client.ListServers(ctx, projectID, region).Details(true).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stackit/server.go
+++ b/pkg/stackit/server.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (cl nodeClient) GetServer(ctx context.Context, projectID, region, serverID string) (*iaas.Server, error) {
-	server, err := cl.client.GetServerExecute(ctx, projectID, region, serverID)
+	server, err := cl.client.GetServer(ctx, projectID, region, serverID).Details(true).Execute()
 	if isOpenAPINotFound(err) {
 		return server, ErrorNotFound
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

Previouly the NodeAddresses slice was incorrectly pre-alloced by using the size of Nics. This doesn't make any sense as usually there is only **one** NIC but multiple Addresses such as, Hostname, IPV4, IPV6, FIP's etc.

It is impossible to know the size of the slice beforehand, so we'll just fill it dynamically.

Additionally this also fixes the problem that fields like `nics` are not populated by default in SDK when the query-parameter `?details=true` is missing. Therefore I also added `Details(true)` to GetServer aswell as ListServers

**Related work items**:

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
