### PR TITLE
Use correct image versions in 1.31 release branch

### DIFF
--- a/deploy/cloud-controller-manager/deployment.yaml
+++ b/deploy/cloud-controller-manager/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: stackit-cloud-controller-manager
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.33
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.31
         args:
         - "--cloud-provider=stackit"
         - "--webhook-secure-port=0"

--- a/deploy/csi-plugin/controllerplugin.yaml
+++ b/deploy/csi-plugin/controllerplugin.yaml
@@ -93,7 +93,7 @@ spec:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - name: stackit-csi-plugin
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:release-v1.33
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:release-v1.31
         args:
         - /bin/stackit-csi-plugin
         - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/csi-plugin/nodeplugin.yaml
+++ b/deploy/csi-plugin/nodeplugin.yaml
@@ -53,7 +53,7 @@ spec:
           capabilities:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:release-v1.33
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:release-v1.31
         args:
         - /bin/stackit-csi-plugin
         - "--endpoint=$(CSI_ENDPOINT)"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: stackit-cloud-controller-manager
       containers:
       - name: stackit-cloud-controller-manager
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.33
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.31
         args:
         # CCM flags
         - --cloud-provider=stackit


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind cleanup

**What this PR does / why we need it**:

Use 1.31 container images in deployment manifests matching the release branch.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
