### PR TITLE
fix: fix key-pair creation in e2e script

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -194,7 +194,7 @@ setup_ssh_key() {
   if ! stackit key-pair describe "$SSH_KEY_NAME" --project-id "$PROJECT_ID" &>/dev/null; then
     log "No existing key found. Creating..."
     # The '@' prefix tells the CLI to read the content from the file
-    if ! stackit key-pair create "$SSH_KEY_NAME" -y \
+    if ! stackit key-pair create --public-key "$SSH_KEY_NAME" -y \
       --project-id "$PROJECT_ID" \
       --public-key "@$HOME/.ssh/$SSH_KEY_NAME.pub"; then
       log_error "Failed to create SSH key '$SSH_KEY_NAME' in STACKIT."


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug

**What this PR does / why we need it**:

Fix `stackit key-pair create` command in e2e test script.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
