### PR TITLE
:bug: [e2e] Fix: Switch from `networkId` to `id`

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -226,7 +226,7 @@ ensure_network() {
     log "Network '$NETWORK_NAME' not found. Creating it..."
     network_id=$(stackit network create --name "$NETWORK_NAME" \
       --project-id "$PROJECT_ID" \
-      --output-format json -y | jq -r ".networkId")
+      --output-format json -y | jq -r ".id")
 
     [[ -n "$network_id" && "$network_id" != "null" ]] || log_error "Failed to create new network '$NETWORK_NAME'."
     log_success "Created network '$NETWORK_NAME' with ID: $network_id"


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Since the STACKIT-CLI switch to IaaS `v1` with the breaking change of the `networkId` to `id`, the script needs to be adjusted to store the network ID correctly for following tasks.