### PR TITLE
fix: revert return codes in controllerserver to codes.Internal

### DIFF
--- a/pkg/csi/blockstorage/controllerserver.go
+++ b/pkg/csi/blockstorage/controllerserver.go
@@ -162,7 +162,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 		snap, err := cloud.GetSnapshotByID(ctx, sourceSnapshotID)
 		if stackiterrors.IgnoreNotFound(err) != nil {
-			return nil, status.Errorf(codes.NotFound, "Failed to retrieve the source snapshot %s: %v", sourceSnapshotID, err)
+			return nil, status.Errorf(codes.Internal, "Failed to retrieve the source snapshot %s: %v", sourceSnapshotID, err)
 		}
 		// If the snapshot exists but is not yet available, fail.
 		if err == nil && *snap.Status != stackit.SnapshotReadyStatus {
@@ -206,7 +206,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			if stackiterrors.IsNotFound(err) {
 				return nil, status.Errorf(codes.NotFound, "Source Volume %s not found", sourceVolID)
 			}
-			return nil, status.Errorf(codes.NotFound, "Failed to retrieve the source volume %s: %v", sourceVolID, err)
+			return nil, status.Errorf(codes.Internal, "Failed to retrieve the source volume %s: %v", sourceVolID, err)
 		}
 		if volAvailability != *sourceVolume.AvailabilityZone {
 			return nil, status.Errorf(codes.ResourceExhausted, "Volume must be in the same availability zone as source Volume. Got %s Required: %s", volAvailability, *sourceVolume.AvailabilityZone)
@@ -357,7 +357,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		if stackiterrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "[ControllerPublishVolume] Volume %s not found", volumeID)
 		}
-		return nil, status.Errorf(codes.NotFound, "[ControllerPublishVolume] get volume failed with error %v", err)
+		return nil, status.Errorf(codes.Internal, "[ControllerPublishVolume] get volume failed with error %v", err)
 	}
 
 	_, err = cloud.GetInstanceByID(ctx, instanceID)
@@ -365,7 +365,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 		if stackiterrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "[ControllerPublishVolume] Instance %s not found", instanceID)
 		}
-		return nil, status.Errorf(codes.NotFound, "[ControllerPublishVolume] GetInstanceByID failed with error %v", err)
+		return nil, status.Errorf(codes.Internal, "[ControllerPublishVolume] GetInstanceByID failed with error %v", err)
 	}
 
 	_, err = cloud.AttachVolume(ctx, instanceID, volumeID)
@@ -840,7 +840,7 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		if stackiterrors.IsNotFound(err) {
 			return nil, status.Errorf(codes.NotFound, "ValidateVolumeCapabilities Volume %s not found", volumeID)
 		}
-		return nil, status.Errorf(codes.NotFound, "ValidateVolumeCapabilities %v", err)
+		return nil, status.Errorf(codes.Internal, "ValidateVolumeCapabilities %v", err)
 	}
 
 	for _, volCap := range reqVolCap {

--- a/pkg/csi/blockstorage/controllerserver_test.go
+++ b/pkg/csi/blockstorage/controllerserver_test.go
@@ -536,7 +536,7 @@ var _ = Describe("ControllerServer test", Ordered, func() {
 
 				_, err := fakeCs.CreateVolume(context.Background(), req)
 				Expect(err).To(HaveOccurred())
-				Expect(status.Code(err)).To(Equal(codes.NotFound))
+				Expect(status.Code(err)).To(Equal(codes.Internal))
 				Expect(err.Error()).To(ContainSubstring("Failed to retrieve the source volume"))
 			})
 		})

--- a/pkg/csi/blockstorage/sanity_test.go
+++ b/pkg/csi/blockstorage/sanity_test.go
@@ -321,7 +321,7 @@ var _ = Describe("CSI sanity test", Ordered, func() {
 				}
 				server, ok := createdInstances[instanceID]
 				if !ok {
-					return nil, status.Error(codes.NotFound, "server not found in mock")
+					return nil, &oapierror.GenericOpenAPIError{StatusCode: http.StatusNotFound}
 				}
 				return server, nil
 			}).AnyTimes()
@@ -333,7 +333,7 @@ var _ = Describe("CSI sanity test", Ordered, func() {
 			).DoAndReturn(func(_ context.Context, instanceID string, volumeID string) (string, error) {
 				vol, ok := createdVolumes[volumeID]
 				if !ok {
-					return "", status.Error(codes.NotFound, "volume not found in mock")
+					return "", &oapierror.GenericOpenAPIError{StatusCode: http.StatusNotFound}
 				}
 				vol.ServerId = ptr.To(instanceID)
 				vol.Status = ptr.To("attached")

--- a/pkg/csi/blockstorage/sanity_test.go
+++ b/pkg/csi/blockstorage/sanity_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/kubernetes-csi/csi-test/v5/pkg/sanity"
 	. "github.com/onsi/ginkgo/v2"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	mountutils "k8s.io/mount-utils"
 	exec "k8s.io/utils/exec/testing"
 	"k8s.io/utils/ptr"
@@ -123,10 +121,6 @@ var _ = Describe("CSI sanity test", Ordered, func() {
 				}
 				return found, nil
 			}).AnyTimes()
-
-			iaasClient.EXPECT().ListVolumes(
-				gomock.Any(), gomock.Any(), gomock.Eq("invalid-token"),
-			).Return(nil, "", status.Error(codes.InvalidArgument, "invalid starting token")).AnyTimes()
 
 			iaasClient.EXPECT().ListVolumes(
 				gomock.Any(), gomock.Any(), gomock.Eq(""),


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug

**What this PR does / why we need it**:

Fix wrong return codes introduces in https://github.com/stackitcloud/cloud-provider-stackit/pull/197. Instead of changing the actual code, the correct approach was to fix the mocks.

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
