### PR TITLE
Unify config files for ccm and csi

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -36,7 +36,7 @@ var (
 func main() {
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {
-		klog.Fatalf("unable to initialize command options: %v", err)
+		klog.Fatalf("Unable to initialize command options: %v", err)
 	}
 
 	fmt.Println("starting Controller")
@@ -91,7 +91,7 @@ func cloudInitializer(ctx context.Context) func(config *cloudcontrollerconfig.Co
 
 		if !cloud.HasClusterID() {
 			if config.ComponentConfig.KubeCloudShared.AllowUntaggedCloud {
-				klog.Warning("detected a cluster without a ClusterID. A ClusterID will be required in the future. Please tag your cluster to avoid any future issues")
+				klog.Warning("Detected a cluster without a ClusterID. A ClusterID will be required in the future. Please tag your cluster to avoid any future issues")
 			} else {
 				klog.Fatalf(
 					"no ClusterID found. A ClusterID is required for the cloud provider to function properly. " +

--- a/deploy/csi-plugin/controllerplugin.yaml
+++ b/deploy/csi-plugin/controllerplugin.yaml
@@ -105,7 +105,7 @@ spec:
         - name: CSI_ENDPOINT
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG
-          value: /etc/config/cloud.conf
+          value: /etc/config/cloud.yaml
         - name: CLUSTER_NAME
           value: kubernetes
         - name: STACKIT_SERVICE_ACCOUNT_KEY_PATH

--- a/deploy/csi-plugin/nodeplugin.yaml
+++ b/deploy/csi-plugin/nodeplugin.yaml
@@ -64,7 +64,7 @@ spec:
         - name: CSI_ENDPOINT
           value: unix://csi/csi.sock
         - name: CLOUD_CONFIG
-          value: /etc/config/cloud.conf
+          value: /etc/config/cloud.yaml
         imagePullPolicy: "IfNotPresent"
         ports:
         - containerPort: 9808

--- a/docs/migration/configuration.md
+++ b/docs/migration/configuration.md
@@ -1,0 +1,97 @@
+# Migration Guide: CCM and CSI Configuration to Unified YAML Format
+
+## Introduction
+
+This guide provides step-by-step instructions for migrating from the legacy Cloud Controller Manager (CCM) and Container Storage Interface (CSI) configurations to the new unified YAML-based configuration format.
+
+## Overview
+
+The migration involves:
+
+- Updating CCM and CSI configurations to use the new unified YAML format
+- Mapping legacy configuration keys to new schema
+- Ensuring compatibility with the latest version of the STACKIT Kubernetes integration
+
+**Note**: While the new format uses a unified structure, CCM and CSI configurations remain in separate files but follow the same YAML schema.
+
+## Removed Configuration Options
+
+The following configuration options have been removed in the new format:
+
+### CCM
+
+- `nonStackitClassNames` - No longer supported
+
+### CSI
+
+- `node-volume-attach-limit` - No longer configurable
+
+## Old Configuration Reference
+
+### CCM Configuration
+
+```yaml
+# cloudprovider.yaml
+projectId: my-stackit-project-id
+networkId: my-stackit-network-id
+region: eu01
+nonStackitClassNames: my-non-stackit-class
+extraLabels:
+  key1: value1
+  key2: value2
+metadata:
+  searchOrder: "configDrive,metadataService"
+  requestTimeout: "5s"
+loadBalancerApi:
+  url: https://loadbalancer.example.com
+```
+
+### CSI Configuration
+
+```ini
+# cloudprovider.conf
+[Global]
+project-id = "my-stackit-project-id"
+iaas-api-url = "https://iaas.example.com"
+[Metadata]
+search-order = "configDrive,metadataService"
+request-timeout = "5s"
+[BlockStorage]
+node-volume-attach-limit = 20
+rescan-on-resize = true
+```
+
+## New Configuration Reference
+
+### CCM Configuration
+
+```yaml
+# cloudprovider.yaml
+global:
+  projectId: my-stackit-project-id
+  region: eu01
+metadata:
+  searchOrder: "configDrive,metadataService"
+  requestTimeout: "5s"
+loadBalancer:
+  api:
+    url: https://loadbalancer.example.com
+  networkId: my-stackit-network-id
+  extraLabels:
+    key1: value1
+    key2: value2
+```
+
+### CSI Configuration
+
+```yaml
+# cloudprovider.conf
+global:
+  projectId: my-stackit-project-id
+  iaasApi: https://iaas.example.com
+metadata:
+  searchOrder: "configDrive,metadataService"
+  requestTimeout: "5s"
+blockStorage:
+  rescanOnResize: true
+```

--- a/docs/migration/configuration.md
+++ b/docs/migration/configuration.md
@@ -74,8 +74,7 @@ metadata:
   searchOrder: "configDrive,metadataService"
   requestTimeout: "5s"
 loadBalancer:
-  api:
-    url: https://loadbalancer.example.com
+  api: https://loadbalancer.example.com
   networkId: my-stackit-network-id
   extraLabels:
     key1: value1

--- a/go.mod
+++ b/go.mod
@@ -19,11 +19,11 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.3.0
 	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.6.2
 	go.uber.org/mock v0.6.0
+	go.yaml.in/yaml/v2 v2.4.3
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.39.0
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
@@ -114,7 +114,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
@@ -130,7 +129,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.34.2 // indirect
 	k8s.io/component-helpers v0.34.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -345,14 +345,10 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSPG+6V4=
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
-gopkg.in/gcfg.v1 v1.2.3 h1:m8OOJ4ccYHnx2f4gQwpno8nAX5OGOh7RLaaz0pj3Ogs=
-gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
-gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
-gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -65,7 +65,7 @@ func NewInstance(client stackit.NodeClient, projectID, region string) (*Instance
 func (i *Instances) InstanceExists(ctx context.Context, node *corev1.Node) (bool, error) {
 	_, err := i.getInstance(ctx, node)
 	if errors.Is(err, cloudprovider.InstanceNotFound) {
-		klog.V(6).Infof("instance not found for node: %s", node.Name)
+		klog.V(6).Infof("Instance not found for node: %s", node.Name)
 		return false, nil
 	}
 	if err != nil {
@@ -94,7 +94,7 @@ func (i *Instances) InstanceShutdown(ctx context.Context, node *corev1.Node) (bo
 func (i *Instances) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudprovider.InstanceMetadata, error) {
 	server, err := i.getInstance(ctx, node)
 	if errors.Is(err, cloudprovider.InstanceNotFound) {
-		klog.V(6).Infof("instance not found for node: %s", node.Name)
+		klog.V(6).Infof("Instance not found for node: %s", node.Name)
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/ccm/loadbalancer_spec.go
+++ b/pkg/ccm/loadbalancer_spec.go
@@ -244,8 +244,7 @@ func getPlanID(service *corev1.Service) (planID *string, msgs []string, err erro
 func lbSpecFromService( //nolint:funlen,gocyclo // It is long but not complex.
 	service *corev1.Service,
 	nodes []*corev1.Node,
-	networkID string,
-	extraLabels map[string]string,
+	opts LoadBalancerOpts,
 	observability *loadbalancer.LoadbalancerOptionObservability,
 ) (*loadbalancer.CreateLoadBalancerPayload, []Event, error) {
 	lb := &loadbalancer.CreateLoadBalancerPayload{
@@ -253,7 +252,7 @@ func lbSpecFromService( //nolint:funlen,gocyclo // It is long but not complex.
 		Networks: &[]loadbalancer.Network{
 			{
 				Role:      utils.Ptr(loadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS),
-				NetworkId: &networkID,
+				NetworkId: &opts.NetworkID,
 			},
 		},
 	}
@@ -262,7 +261,7 @@ func lbSpecFromService( //nolint:funlen,gocyclo // It is long but not complex.
 		lb.Networks = &[]loadbalancer.Network{
 			{
 				Role:      utils.Ptr(loadbalancer.NETWORKROLE_TARGETS),
-				NetworkId: &networkID,
+				NetworkId: &opts.NetworkID,
 			}, {
 				Role:      utils.Ptr(loadbalancer.NETWORKROLE_LISTENERS),
 				NetworkId: &listenerNetwork,
@@ -272,14 +271,14 @@ func lbSpecFromService( //nolint:funlen,gocyclo // It is long but not complex.
 		lb.Networks = &[]loadbalancer.Network{
 			{
 				Role:      utils.Ptr(loadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS),
-				NetworkId: &networkID,
+				NetworkId: &opts.NetworkID,
 			},
 		}
 	}
 
 	// Add extraLabels if set
-	if extraLabels != nil {
-		lb.Labels = ptr.To(extraLabels)
+	if opts.ExtraLabels != nil {
+		lb.Labels = ptr.To(opts.ExtraLabels)
 	}
 
 	// Add metric metricsRemoteWrite settings

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -50,52 +50,53 @@ type Config struct {
 
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		cfg, err := ReadConfig(config)
+		cfg, err := GetConfig(config)
 		if err != nil {
-			klog.Warningf("failed to read config: %v", err)
 			return nil, err
 		}
+
+		if cfg.Global.ProjectID == "" {
+			return nil, errors.New("projectId must be set")
+		}
+		if cfg.Global.Region == "" {
+			return nil, errors.New("region must be set")
+		}
+
+		if cfg.LoadBalancer.API == "" {
+			cfg.LoadBalancer.API = "https://load-balancer.api.eu01.stackit.cloud"
+		}
+		if cfg.LoadBalancer.NetworkID == "" {
+			return nil, errors.New("networkId must be set")
+		}
+
 		obs, err := BuildObservability()
 		if err != nil {
-			klog.Warningf("failed to build metricsRemoteWrite: %v", err)
 			return nil, err
 		}
 		cloud, err := NewCloudControllerManager(&cfg, obs)
 		if err != nil {
-			klog.Warningf("failed to create STACKIT cloud provider: %v", err)
+			klog.Warningf("Failed to create STACKIT cloud provider: %v", err)
 		}
 		return cloud, err
 	})
 }
 
-func ReadConfig(configReader io.Reader) (Config, error) {
-	if configReader == nil {
-		return Config{}, errors.New("cloud config is missing")
-	}
-	configBytes, err := io.ReadAll(configReader)
+func GetConfig(reader io.Reader) (Config, error) {
+	var cfg Config
+
+	content, err := io.ReadAll(reader)
 	if err != nil {
-		return Config{}, err
-	}
-	config := Config{}
-	err = yaml.Unmarshal(configBytes, &config)
-	if err != nil {
-		return Config{}, err
-	}
-	if config.Global.ProjectID == "" {
-		return Config{}, errors.New("projectId must be set")
-	}
-	if config.Global.Region == "" {
-		return Config{}, errors.New("region must be set")
+		klog.ErrorS(err, "Failed to read config content")
+		return cfg, err
 	}
 
-	if config.LoadBalancer.API == "" {
-		config.LoadBalancer.API = "https://load-balancer.api.eu01.stackit.cloud"
-	}
-	if config.LoadBalancer.NetworkID == "" {
-		return Config{}, errors.New("networkId must be set")
+	err = yaml.Unmarshal(content, &cfg)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse config as YAML")
+		return cfg, err
 	}
 
-	return config, nil
+	return cfg, nil
 }
 
 func BuildObservability() (*MetricsRemoteWrite, error) {
@@ -136,7 +137,7 @@ func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudCont
 	// In those cases, the [cfg.LoadBalancerAPI.URL] will also be different (direct API URL instead of the API Gateway)
 	lbEmergencyAPIToken := os.Getenv(stackitLoadBalancerEmergencyAPIToken)
 	if lbEmergencyAPIToken != "" {
-		klog.Warningf("using emergency token for loadbalancer api on host: %s", cfg.LoadBalancer.API)
+		klog.Warningf("Using emergency token for loadbalancer api on host: %s", cfg.LoadBalancer.API)
 		lbOpts = append(lbOpts, sdkconfig.WithToken(lbEmergencyAPIToken))
 	}
 

--- a/pkg/ccm/stackit_test.go
+++ b/pkg/ccm/stackit_test.go
@@ -1,12 +1,138 @@
-package ccm_test
+package ccm
 
 import (
+	"bytes"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("DummyTest", func() {
-	Describe("Should Pass", func() {
-		Expect(true).To(BeTrue())
+var _ = Describe("GetConfig", func() {
+	It("should parse valid YAML configuration", func() {
+		validYAML := `
+global:
+  projectId: "test-project"
+  region: "eu01"
+metadata:
+  searchOrder: "metadataService,configDrive"
+loadBalancer:
+  api: "https://load-balancer.api.eu01.stackit.cloud"
+  networkId: "test-network"
+`
+
+		config, err := GetConfig(strings.NewReader(validYAML))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Global.ProjectID).To(Equal("test-project"))
+		Expect(config.Global.Region).To(Equal("eu01"))
+		Expect(config.Metadata.SearchOrder).To(Equal("metadataService,configDrive"))
+		Expect(config.LoadBalancer.API).To(Equal("https://load-balancer.api.eu01.stackit.cloud"))
+		Expect(config.LoadBalancer.NetworkID).To(Equal("test-network"))
+	})
+
+	It("should handle missing optional fields", func() {
+		minimalYAML := `
+global:
+  projectId: "my-project"
+  region: "eu01"
+loadBalancer:
+  networkId: "my-network"
+`
+
+		config, err := GetConfig(strings.NewReader(minimalYAML))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Global.ProjectID).To(Equal("my-project"))
+		Expect(config.Global.Region).To(Equal("eu01"))
+		Expect(config.LoadBalancer.NetworkID).To(Equal("my-network"))
+		Expect(config.LoadBalancer.API).To(BeEmpty())
+	})
+
+	It("should handle configuration with extra labels", func() {
+		yamlWithLabels := `
+global:
+  projectId: "test-project"
+  region: "eu01"
+loadBalancer:
+  networkId: "test-network"
+  extraLabels:
+    environment: "production"
+    team: "platform"
+`
+
+		config, err := GetConfig(strings.NewReader(yamlWithLabels))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.LoadBalancer.ExtraLabels).To(HaveKeyWithValue("environment", "production"))
+		Expect(config.LoadBalancer.ExtraLabels).To(HaveKeyWithValue("team", "platform"))
+	})
+
+	It("should return error for malformed YAML", func() {
+		invalidYAML := `
+global:
+  projectId: "test-project"
+  region: "eu01"
+  invalid yaml syntax here [[[
+`
+
+		_, err := GetConfig(strings.NewReader(invalidYAML))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should handle empty YAML gracefully", func() {
+		emptyYAML := ``
+
+		config, err := GetConfig(strings.NewReader(emptyYAML))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config).To(Equal(Config{}))
+	})
+
+	It("should return error for invalid YAML structure", func() {
+		invalidStructure := `
+this is not valid yaml structure
+- random: content
+`
+
+		_, err := GetConfig(strings.NewReader(invalidStructure))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should handle YAML with comments", func() {
+		yamlWithComments := `
+# This is a comment
+global:
+  projectId: "test-project" # inline comment
+  region: "eu01"
+# Another comment
+loadBalancer:
+  networkId: "test-network"
+`
+
+		config, err := GetConfig(strings.NewReader(yamlWithComments))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Global.ProjectID).To(Equal("test-project"))
+		Expect(config.LoadBalancer.NetworkID).To(Equal("test-network"))
+	})
+
+	It("should handle YAML with different string quote styles", func() {
+		mixedQuotesYAML := `
+global:
+  projectId: "test-project"
+  region: 'eu01'
+loadBalancer:
+  networkId: test-network
+`
+
+		config, err := GetConfig(strings.NewReader(mixedQuotesYAML))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Global.ProjectID).To(Equal("test-project"))
+		Expect(config.Global.Region).To(Equal("eu01"))
+		Expect(config.LoadBalancer.NetworkID).To(Equal("test-network"))
+	})
+
+	It("should handle empty reader gracefully", func() {
+		emptyReader := bytes.NewReader([]byte{})
+
+		config, err := GetConfig(emptyReader)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config).To(Equal(Config{}))
 	})
 })

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -16,7 +16,7 @@ func Run(ctx context.Context, metricsAddr string) error {
 		return errors.New("metrics address is empty")
 	}
 
-	klog.Infof("starting prometheus listener on address %s", metricsAddr)
+	klog.Infof("Starting prometheus listener on address %s", metricsAddr)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
@@ -39,7 +39,7 @@ func Run(ctx context.Context, metricsAddr string) error {
 
 	g.Go(func() error {
 		<-gCtx.Done()
-		klog.Info("shutdown prometheus listener")
+		klog.Info("Shutdown prometheus listener")
 		return serv.Shutdown(gCtx)
 	})
 

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -124,27 +124,20 @@ func (os *iaasClient) GetBlockStorageOpts() BlockStorageOpts {
 	return os.bsOpts
 }
 
-type LoadBalancerOpts struct {
-	API string `yaml:"api"`
-}
-
 type BlockStorageOpts struct {
 	RescanOnResize bool `yaml:"rescanOnResize"`
 }
 
 type GlobalOpts struct {
-	ProjectID   string            `yaml:"projectId"`
-	IaasAPI     string            `yaml:"iaasApi"`
-	NetworkID   string            `yaml:"networkId"`
-	ExtraLabels map[string]string `yaml:"extraLabels"`
-	Region      string            `yaml:"region"`
+	ProjectID string `yaml:"projectId"`
+	IaasAPI   string `yaml:"iaasApi"`
+	Region    string `yaml:"region"`
 }
 
 type Config struct {
 	Global       GlobalOpts       `yaml:"global"`
 	Metadata     metadata.Opts    `yaml:"metadata"`
 	BlockStorage BlockStorageOpts `yaml:"blockStorage"`
-	LoadBalancer LoadBalancerOpts `yaml:"loadBalancer"`
 }
 
 func GetConfig(reader io.Reader) (Config, error) {

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -28,7 +29,7 @@ import (
 	oapiError "github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
-	"gopkg.in/gcfg.v1"
+	"go.yaml.in/yaml/v2"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/version"
@@ -123,19 +124,45 @@ func (os *iaasClient) GetBlockStorageOpts() BlockStorageOpts {
 	return os.bsOpts
 }
 
+type LoadBalancerOpts struct {
+	API string `yaml:"api"`
+}
+
 type BlockStorageOpts struct {
-	RescanOnResize bool `gcfg:"rescan-on-resize"`
+	RescanOnResize bool `yaml:"rescanOnResize"`
 }
 
 type GlobalOpts struct {
-	ProjectID  string `gcfg:"project-id"`
-	IaasAPIURL string `gcfg:"iaas-api-url"`
+	ProjectID   string            `yaml:"projectId"`
+	IaasAPI     string            `yaml:"iaasApi"`
+	NetworkID   string            `yaml:"networkId"`
+	ExtraLabels map[string]string `yaml:"extraLabels"`
+	Region      string            `yaml:"region"`
 }
 
 type Config struct {
-	Global       GlobalOpts
-	Metadata     metadata.Opts
-	BlockStorage BlockStorageOpts
+	Global       GlobalOpts       `yaml:"global"`
+	Metadata     metadata.Opts    `yaml:"metadata"`
+	BlockStorage BlockStorageOpts `yaml:"blockStorage"`
+	LoadBalancer LoadBalancerOpts `yaml:"loadBalancer"`
+}
+
+func GetConfig(reader io.Reader) (Config, error) {
+	var cfg Config
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		klog.ErrorS(err, "Failed to read config content")
+		return cfg, err
+	}
+
+	err = yaml.Unmarshal(content, &cfg)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse config as YAML")
+		return cfg, err
+	}
+
+	return cfg, nil
 }
 
 func GetConfigFromFile(path string) (Config, error) {
@@ -148,12 +175,7 @@ func GetConfigFromFile(path string) (Config, error) {
 	}
 	defer config.Close()
 
-	err = gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
-	if err != nil {
-		klog.ErrorS(err, "Failed to parse config file", "path", path)
-		return cfg, err
-	}
-	return cfg, nil
+	return GetConfig(config)
 }
 
 // CreateSTACKITProvider creates STACKIT Instance
@@ -183,8 +205,8 @@ func CreateIaaSClient(cfg *Config) (iaas.DefaultApi, error) {
 	}
 	klog.V(4).Infof("Using user-agent: %s", userAgent)
 
-	if cfg.Global.IaasAPIURL != "" {
-		opts = append(opts, sdkconfig.WithEndpoint(cfg.Global.IaasAPIURL))
+	if cfg.Global.IaasAPI != "" {
+		opts = append(opts, sdkconfig.WithEndpoint(cfg.Global.IaasAPI))
 	}
 
 	opts = append(opts, sdkconfig.WithUserAgent(strings.Join(userAgent, " ")))

--- a/pkg/stackit/client_test.go
+++ b/pkg/stackit/client_test.go
@@ -1,35 +1,178 @@
 package stackit
 
 import (
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
-	"gopkg.in/gcfg.v1"
 )
 
 var _ = Describe("Client", func() {
 	Describe("Config", func() {
-		It("should parse from ini", func() {
-			var cfg Config
+		Describe("GetConfig", func() {
+			It("should parse valid yaml configuration", func() {
+				cfg, err := GetConfig(strings.NewReader(validYamlConf))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.Metadata).To(Equal(metadata.Opts{
+					SearchOrder:    "configDrive,metadataService",
+					RequestTimeout: metadata.Duration{Duration: 5 * time.Second},
+				}))
+				Expect(cfg.BlockStorage).To(Equal(BlockStorageOpts{
+					RescanOnResize: true,
+				}))
+				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
+				Expect(cfg.Global.Region).To(Equal("eu01"))
+				Expect(cfg.Global.IaasAPI).To(Equal("https://api.example.com"))
+				Expect(cfg.Global.NetworkID).To(Equal("test-network"))
+				Expect(cfg.Global.ExtraLabels).To(Equal(map[string]string{"env": "test"}))
+				Expect(cfg.LoadBalancer.API).To(Equal("https://lb-api.example.com"))
+			})
 
-			Expect(gcfg.FatalOnly(gcfg.ReadInto(&cfg, strings.NewReader(iniConf)))).To(Succeed())
-			Expect(cfg.Metadata).To(Equal(metadata.Opts{
-				RequestTimeout: metadata.Duration{Duration: 5 * time.Second},
-			},
-			))
-			Expect(cfg.BlockStorage).To(Equal(BlockStorageOpts{
-				RescanOnResize: true,
-			}))
+			It("should handle missing optional fields", func() {
+				cfg, err := GetConfig(strings.NewReader(minimalYamlConf))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
+				Expect(cfg.Global.Region).To(Equal("eu01"))
+				// Optional fields should be empty/zero values
+				Expect(cfg.Global.IaasAPI).To(BeEmpty())
+				Expect(cfg.Global.NetworkID).To(BeEmpty())
+				Expect(cfg.Global.ExtraLabels).To(BeEmpty())
+			})
+
+			It("should return error for invalid yaml", func() {
+				_, err := GetConfig(strings.NewReader(invalidYamlConf))
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should handle empty yaml gracefully", func() {
+				cfg, err := GetConfig(strings.NewReader(emptyYamlConf))
+				Expect(err).NotTo(HaveOccurred())
+				// Empty YAML should result in zero values
+				Expect(cfg).To(Equal(Config{}))
+			})
+		})
+
+		Describe("GetConfigFromFile", func() {
+			var tempFile *os.File
+			var tempFilePath string
+
+			BeforeEach(func() {
+				var err error
+				tempFile, err = os.CreateTemp("", "test-config-*.yaml")
+				Expect(err).NotTo(HaveOccurred())
+				tempFilePath = tempFile.Name()
+			})
+
+			AfterEach(func() {
+				if tempFile != nil {
+					tempFile.Close()
+					os.Remove(tempFilePath)
+				}
+			})
+
+			It("should read configuration from file", func() {
+				_, err := tempFile.WriteString(validYamlConf)
+				Expect(err).NotTo(HaveOccurred())
+				tempFile.Close()
+
+				cfg, err := GetConfigFromFile(tempFilePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
+			})
+
+			It("should return error for non-existent file", func() {
+				_, err := GetConfigFromFile("non-existent-file.yaml")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Metadata Duration Parsing", func() {
+			DescribeTable("should parse various duration formats",
+				func(durationStr string, expected time.Duration) {
+					yaml := fmt.Sprintf(`
+global:
+  projectId: "test-project"
+  region: "eu01"
+metadata:
+  requestTimeout: "%s"`, durationStr)
+
+					cfg, err := GetConfig(strings.NewReader(yaml))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cfg.Metadata.RequestTimeout.Duration).To(Equal(expected))
+				},
+				Entry("seconds", "5s", 5*time.Second),
+				Entry("minutes", "1m", 1*time.Minute),
+				Entry("hours", "2h", 2*time.Hour),
+				Entry("milliseconds", "300ms", 300*time.Millisecond),
+				Entry("complex duration", "1h30m15s", 1*time.Hour+30*time.Minute+15*time.Second),
+			)
+
+			It("should return error for invalid duration format", func() {
+				yaml := `
+global:
+  projectId: "test-project"
+  region: "eu01"
+metadata:
+  requestTimeout: "invalid-duration"`
+
+				_, err := GetConfig(strings.NewReader(yaml))
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Metadata Search Order Validation", func() {
+			DescribeTable("should validate search order format",
+				func(searchOrder string, shouldError bool, errorMsg string) {
+					err := metadata.CheckMetadataSearchOrder(searchOrder)
+					if shouldError {
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring(errorMsg))
+					} else {
+						Expect(err).NotTo(HaveOccurred())
+					}
+				},
+				Entry("valid configDrive,metadataService", "configDrive,metadataService", false, ""),
+				Entry("valid metadataService,configDrive", "metadataService,configDrive", false, ""),
+				Entry("valid single configDrive", "configDrive", false, ""),
+				Entry("valid single metadataService", "metadataService", false, ""),
+				Entry("empty search order", "", true, "metadata.searchOrder"),
+				Entry("too many elements", "configDrive,metadataService,extra", true, "metadata.searchOrder"),
+				Entry("invalid element", "invalid", true, "metadata.searchOrder"),
+				Entry("mixed valid and invalid", "configDrive,invalid", true, "metadata.searchOrder"),
+			)
 		})
 	})
 })
 
-var iniConf = `
-[BlockStorage]
-rescan-on-resize=true
-[Metadata]
-request-timeout=5s
-`
+const validYamlConf = `
+global:
+  projectId: "test-project"
+  iaasApi: "https://api.example.com"
+  networkId: "test-network"
+  extraLabels:
+    env: "test"
+  region: "eu01"
+metadata:
+  searchOrder: "configDrive,metadataService"
+  requestTimeout: "5s"
+blockStorage:
+  rescanOnResize: true
+loadBalancer:
+  api: "https://lb-api.example.com"`
+
+const minimalYamlConf = `
+global:
+  projectId: "test-project"
+  region: "eu01"`
+
+const invalidYamlConf = `
+global:
+  projectId: "test-project"
+  region: "eu01"
+  invalid yaml syntax here [[[`
+
+const emptyYamlConf = ``

--- a/pkg/stackit/client_test.go
+++ b/pkg/stackit/client_test.go
@@ -12,138 +12,9 @@ import (
 )
 
 var _ = Describe("Client", func() {
-	Describe("Config", func() {
-		Describe("GetConfig", func() {
-			It("should parse valid yaml configuration", func() {
-				cfg, err := GetConfig(strings.NewReader(validYamlConf))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.Metadata).To(Equal(metadata.Opts{
-					SearchOrder:    "configDrive,metadataService",
-					RequestTimeout: metadata.Duration{Duration: 5 * time.Second},
-				}))
-				Expect(cfg.BlockStorage).To(Equal(BlockStorageOpts{
-					RescanOnResize: true,
-				}))
-				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
-				Expect(cfg.Global.Region).To(Equal("eu01"))
-				Expect(cfg.Global.IaasAPI).To(Equal("https://api.example.com"))
-			})
-
-			It("should handle missing optional fields", func() {
-				cfg, err := GetConfig(strings.NewReader(minimalYamlConf))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
-				Expect(cfg.Global.Region).To(Equal("eu01"))
-				// Optional fields should be empty/zero values
-				Expect(cfg.Global.IaasAPI).To(BeEmpty())
-			})
-
-			It("should return error for invalid yaml", func() {
-				_, err := GetConfig(strings.NewReader(invalidYamlConf))
-				Expect(err).To(HaveOccurred())
-			})
-
-			It("should handle empty yaml gracefully", func() {
-				cfg, err := GetConfig(strings.NewReader(emptyYamlConf))
-				Expect(err).NotTo(HaveOccurred())
-				// Empty YAML should result in zero values
-				Expect(cfg).To(Equal(Config{}))
-			})
-		})
-
-		Describe("GetConfigFromFile", func() {
-			var tempFile *os.File
-			var tempFilePath string
-
-			BeforeEach(func() {
-				var err error
-				tempFile, err = os.CreateTemp("", "test-config-*.yaml")
-				Expect(err).NotTo(HaveOccurred())
-				tempFilePath = tempFile.Name()
-			})
-
-			AfterEach(func() {
-				if tempFile != nil {
-					tempFile.Close()
-					os.Remove(tempFilePath)
-				}
-			})
-
-			It("should read configuration from file", func() {
-				_, err := tempFile.WriteString(validYamlConf)
-				Expect(err).NotTo(HaveOccurred())
-				tempFile.Close()
-
-				cfg, err := GetConfigFromFile(tempFilePath)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
-			})
-
-			It("should return error for non-existent file", func() {
-				_, err := GetConfigFromFile("non-existent-file.yaml")
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Describe("Metadata Duration Parsing", func() {
-			DescribeTable("should parse various duration formats",
-				func(durationStr string, expected time.Duration) {
-					yaml := fmt.Sprintf(`
-global:
-  projectId: "test-project"
-  region: "eu01"
-metadata:
-  requestTimeout: "%s"`, durationStr)
-
-					cfg, err := GetConfig(strings.NewReader(yaml))
-					Expect(err).NotTo(HaveOccurred())
-					Expect(cfg.Metadata.RequestTimeout.Duration).To(Equal(expected))
-				},
-				Entry("seconds", "5s", 5*time.Second),
-				Entry("minutes", "1m", 1*time.Minute),
-				Entry("hours", "2h", 2*time.Hour),
-				Entry("milliseconds", "300ms", 300*time.Millisecond),
-				Entry("complex duration", "1h30m15s", 1*time.Hour+30*time.Minute+15*time.Second),
-			)
-
-			It("should return error for invalid duration format", func() {
-				yaml := `
-global:
-  projectId: "test-project"
-  region: "eu01"
-metadata:
-  requestTimeout: "invalid-duration"`
-
-				_, err := GetConfig(strings.NewReader(yaml))
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Describe("Metadata Search Order Validation", func() {
-			DescribeTable("should validate search order format",
-				func(searchOrder string, shouldError bool, errorMsg string) {
-					err := metadata.CheckMetadataSearchOrder(searchOrder)
-					if shouldError {
-						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(ContainSubstring(errorMsg))
-					} else {
-						Expect(err).NotTo(HaveOccurred())
-					}
-				},
-				Entry("valid configDrive,metadataService", "configDrive,metadataService", false, ""),
-				Entry("valid metadataService,configDrive", "metadataService,configDrive", false, ""),
-				Entry("valid single configDrive", "configDrive", false, ""),
-				Entry("valid single metadataService", "metadataService", false, ""),
-				Entry("empty search order", "", true, "metadata.searchOrder"),
-				Entry("too many elements", "configDrive,metadataService,extra", true, "metadata.searchOrder"),
-				Entry("invalid element", "invalid", true, "metadata.searchOrder"),
-				Entry("mixed valid and invalid", "configDrive,invalid", true, "metadata.searchOrder"),
-			)
-		})
-	})
-})
-
-const validYamlConf = `
+	Describe("GetConfig", func() {
+		It("should parse valid yaml configuration", func() {
+			cfg, err := GetConfig(strings.NewReader(`
 global:
   projectId: "test-project"
   iaasApi: "https://api.example.com"
@@ -152,17 +23,145 @@ metadata:
   searchOrder: "configDrive,metadataService"
   requestTimeout: "5s"
 blockStorage:
-  rescanOnResize: true`
+  rescanOnResize: true`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Metadata).To(Equal(metadata.Opts{
+				SearchOrder:    "configDrive,metadataService",
+				RequestTimeout: metadata.Duration{Duration: 5 * time.Second},
+			}))
+			Expect(cfg.BlockStorage).To(Equal(BlockStorageOpts{
+				RescanOnResize: true,
+			}))
+			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
+			Expect(cfg.Global.Region).To(Equal("eu01"))
+			Expect(cfg.Global.IaasAPI).To(Equal("https://api.example.com"))
+		})
 
-const minimalYamlConf = `
+		It("should handle missing optional fields", func() {
+			cfg, err := GetConfig(strings.NewReader(`
 global:
   projectId: "test-project"
-  region: "eu01"`
+  region: "eu01"`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
+			Expect(cfg.Global.Region).To(Equal("eu01"))
+			// Optional fields should be empty/zero values
+			Expect(cfg.Global.IaasAPI).To(BeEmpty())
+		})
 
-const invalidYamlConf = `
+		It("should return error for invalid yaml", func() {
+			_, err := GetConfig(strings.NewReader(`
 global:
   projectId: "test-project"
   region: "eu01"
-  invalid yaml syntax here [[[`
+  invalid yaml syntax here [[[`))
+			Expect(err).To(HaveOccurred())
+		})
 
-const emptyYamlConf = ``
+		It("should handle empty yaml gracefully", func() {
+			cfg, err := GetConfig(strings.NewReader(``))
+			Expect(err).NotTo(HaveOccurred())
+			// Empty YAML should result in zero values
+			Expect(cfg).To(Equal(Config{}))
+		})
+	})
+
+	Describe("GetConfigFromFile", func() {
+		var tempFile *os.File
+		var tempFilePath string
+
+		BeforeEach(func() {
+			var err error
+			tempFile, err = os.CreateTemp("", "test-config-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			tempFilePath = tempFile.Name()
+		})
+
+		AfterEach(func() {
+			if tempFile != nil {
+				tempFile.Close()
+				os.Remove(tempFilePath)
+			}
+		})
+
+		It("should read configuration from file", func() {
+			_, err := tempFile.WriteString(`
+global:
+  projectId: "test-project"
+  iaasApi: "https://api.example.com"
+  region: "eu01"
+metadata:
+  searchOrder: "configDrive,metadataService"
+  requestTimeout: "5s"
+blockStorage:
+  rescanOnResize: true`)
+			Expect(err).NotTo(HaveOccurred())
+			tempFile.Close()
+
+			cfg, err := GetConfigFromFile(tempFilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
+		})
+
+		It("should return error for non-existent file", func() {
+			_, err := GetConfigFromFile("non-existent-file.yaml")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Metadata Duration Parsing", func() {
+		DescribeTable("should parse various duration formats",
+			func(durationStr string, expected time.Duration) {
+				yaml := fmt.Sprintf(`
+global:
+  projectId: "test-project"
+  region: "eu01"
+metadata:
+  requestTimeout: "%s"`, durationStr)
+
+				cfg, err := GetConfig(strings.NewReader(yaml))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.Metadata.RequestTimeout.Duration).To(Equal(expected))
+			},
+			Entry("seconds", "5s", 5*time.Second),
+			Entry("minutes", "1m", 1*time.Minute),
+			Entry("hours", "2h", 2*time.Hour),
+			Entry("milliseconds", "300ms", 300*time.Millisecond),
+			Entry("complex duration", "1h30m15s", 1*time.Hour+30*time.Minute+15*time.Second),
+		)
+
+		It("should return error for invalid duration format", func() {
+			yaml := `
+global:
+  projectId: "test-project"
+  region: "eu01"
+metadata:
+  requestTimeout: "invalid-duration"`
+
+			_, err := GetConfig(strings.NewReader(yaml))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Metadata Search Order Validation", func() {
+		DescribeTable("should validate search order format",
+			func(searchOrder string, shouldError bool, errorMsg string) {
+				err := metadata.CheckMetadataSearchOrder(searchOrder)
+				if shouldError {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(errorMsg))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			},
+			Entry("valid configDrive,metadataService", "configDrive,metadataService", false, ""),
+			Entry("valid metadataService,configDrive", "metadataService,configDrive", false, ""),
+			Entry("valid single configDrive", "configDrive", false, ""),
+			Entry("valid single metadataService", "metadataService", false, ""),
+			Entry("empty search order", "", true, "metadata.searchOrder"),
+			Entry("too many elements", "configDrive,metadataService,extra", true, "metadata.searchOrder"),
+			Entry("invalid element", "invalid", true, "metadata.searchOrder"),
+			Entry("mixed valid and invalid", "configDrive,invalid", true, "metadata.searchOrder"),
+		)
+	})
+})

--- a/pkg/stackit/client_test.go
+++ b/pkg/stackit/client_test.go
@@ -27,9 +27,6 @@ var _ = Describe("Client", func() {
 				Expect(cfg.Global.ProjectID).To(Equal("test-project"))
 				Expect(cfg.Global.Region).To(Equal("eu01"))
 				Expect(cfg.Global.IaasAPI).To(Equal("https://api.example.com"))
-				Expect(cfg.Global.NetworkID).To(Equal("test-network"))
-				Expect(cfg.Global.ExtraLabels).To(Equal(map[string]string{"env": "test"}))
-				Expect(cfg.LoadBalancer.API).To(Equal("https://lb-api.example.com"))
 			})
 
 			It("should handle missing optional fields", func() {
@@ -39,8 +36,6 @@ var _ = Describe("Client", func() {
 				Expect(cfg.Global.Region).To(Equal("eu01"))
 				// Optional fields should be empty/zero values
 				Expect(cfg.Global.IaasAPI).To(BeEmpty())
-				Expect(cfg.Global.NetworkID).To(BeEmpty())
-				Expect(cfg.Global.ExtraLabels).To(BeEmpty())
 			})
 
 			It("should return error for invalid yaml", func() {
@@ -152,17 +147,12 @@ const validYamlConf = `
 global:
   projectId: "test-project"
   iaasApi: "https://api.example.com"
-  networkId: "test-network"
-  extraLabels:
-    env: "test"
   region: "eu01"
 metadata:
   searchOrder: "configDrive,metadataService"
   requestTimeout: "5s"
 blockStorage:
-  rescanOnResize: true
-loadBalancer:
-  api: "https://lb-api.example.com"`
+  rescanOnResize: true`
 
 const minimalYamlConf = `
 global:

--- a/pkg/stackit/metadata/metadata.go
+++ b/pkg/stackit/metadata/metadata.go
@@ -69,8 +69,8 @@ var metadataCache *Metadata
 // revive:enable:exported
 // Opts is used for configuring how to talk to metadata service or config drive
 type Opts struct {
-	SearchOrder    string   `gcfg:"search-order"`
-	RequestTimeout Duration `gcfg:"request-timeout"`
+	SearchOrder    string   `yaml:"searchOrder"`
+	RequestTimeout Duration `yaml:"requestTimeout"`
 }
 
 // Duration is the encoding.TextUnmarshaler interface for time.Duration
@@ -366,12 +366,12 @@ func (m *metadataService) GetFlavor(ctx context.Context) (string, error) {
 
 func CheckMetadataSearchOrder(order string) error {
 	if order == "" {
-		return errors.New("invalid value in section [Metadata] with key `search-order`. Value cannot be empty")
+		return errors.New("invalid value in metadata.searchOrder. Value cannot be empty")
 	}
 
 	elements := strings.Split(order, ",")
 	if len(elements) > 2 {
-		return errors.New("invalid value in section [Metadata] with key `search-order`. Value cannot contain more than 2 elements")
+		return errors.New("invalid value in metadata.searchOrder. Value cannot contain more than 2 elements")
 	}
 
 	for _, id := range elements {
@@ -380,7 +380,7 @@ func CheckMetadataSearchOrder(order string) error {
 		case ConfigDriveID:
 		case MetadataID:
 		default:
-			return fmt.Errorf("invalid element %q found in section [Metadata] with key `search-order`."+
+			return fmt.Errorf("invalid element %q found in metadata.searchOrder."+
 				"Supported elements include %q and %q", id, ConfigDriveID, MetadataID)
 		}
 	}

--- a/pkg/stackit/volumes.go
+++ b/pkg/stackit/volumes.go
@@ -170,7 +170,7 @@ func (os *iaasClient) DetachVolume(ctx context.Context, instanceID, volumeID str
 		return err
 	}
 	if *volume.Status == VolumeAvailableStatus {
-		klog.V(2).Infof("volume: %s has been detached from compute: %s ", *volume.Id, instanceID)
+		klog.V(2).Infof("Volume: %s has been detached from compute: %s ", *volume.Id, instanceID)
 		return nil
 	}
 

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -779,12 +779,9 @@ data:
     projectId: $project_id
     networkId: $network_id
     region: eu01
-  cloud.conf: |-
-    [Global]
-    project-id = $project_id
-    [BlockStorage]
-    node-volume-attach-limit = 20
-    rescan-on-resize = true
+    blockStorage:
+      nodeVolumeAttachLimit: 20
+      rescanOnResize: true
 EOT_CM
 log "ConfigMap stackit-cloud-controller-manager created in kube-system."
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

Instead of using two different config formats (YAML and INI) the code was reworked to use the same YAML config for both CCM and CSI.

**Special notes for your reviewer**:

**Breaking changes**:

/hold

This change is breaking. Users must migrate their deployments for both CCM and CSI to the new YAML configuration. Even with the existing YAML configuration, the structure and names of the options have changed and must be adjusted.

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
