### PR TITLE
Drop prealloc linter from golangci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,6 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    - prealloc
     - revive
     - rowserrcheck
     - staticcheck


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

Fixes: https://github.com/stackitcloud/cloud-provider-stackit/pull/398

I don't think the prealloc linter makes sense at all for this project.