### PR TITLE
Remove default overwrite of LoadBalancer API endpoint

### DIFF
--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -63,9 +63,6 @@ func init() {
 			return nil, errors.New("region must be set")
 		}
 
-		if cfg.LoadBalancer.API == "" {
-			cfg.LoadBalancer.API = "https://load-balancer.api.eu01.stackit.cloud"
-		}
 		if cfg.LoadBalancer.NetworkID == "" {
 			return nil, errors.New("networkId must be set")
 		}
@@ -130,8 +127,11 @@ func BuildObservability() (*MetricsRemoteWrite, error) {
 // NewCloudControllerManager creates a new instance of the stackit struct from a config struct
 func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
 	lbOpts := []sdkconfig.ConfigurationOption{
-		sdkconfig.WithEndpoint(cfg.LoadBalancer.API),
 		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
+	}
+
+	if cfg.LoadBalancer.API != "" {
+		lbOpts = append(lbOpts, sdkconfig.WithEndpoint(cfg.LoadBalancer.API))
 	}
 
 	// The token is only provided by the 'gardener-extension-provider-stackit' in case of emergency access.


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR removes the default of the LoadBalancer API endpoint which is applied to the config, as the SDK already defaults which also includes the a "variable" region.

