### PR TITLE
Pin apko package versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ $(BUILD_IMAGES): $(SOURCES)
 		cmd/$@/main.go
 
 .PHONY: images
-images: verify-image-stackit-csi-plugin
 images: $(foreach image,$(BUILD_IMAGES),image-$(image))
 
 # lazy reference, evaluated when called

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ $(BUILD_IMAGES): $(SOURCES)
 		cmd/$@/main.go
 
 .PHONY: images
+images: verify-image-stackit-csi-plugin
 images: $(foreach image,$(BUILD_IMAGES),image-$(image))
 
 # lazy reference, evaluated when called

--- a/cmd/stackit-csi-plugin/apko-base-image.yaml
+++ b/cmd/stackit-csi-plugin/apko-base-image.yaml
@@ -4,20 +4,21 @@ contents:
   repositories:
   - https://packages.wolfi.dev/os
   packages:
-  - ca-certificates
-  - blkid
-  - blockdev
-  - e2fsprogs
-  - e2fsprogs-extra
-  - lsblk
-  - mount
-  - umount
-  - btrfs-progs
-  - udev
-  - util-linux-misc # contains fsck
-  - xfsprogs 
-  - xfsprogs-extra # contains xfs_io
-  - findmnt
+  - busybox
+  - ca-certificates=~20250911
+  - blkid=~2.41.2
+  - blockdev=~2.41.2
+  - e2fsprogs=~1.47.3
+  - e2fsprogs-extra=~1.47.3
+  - lsblk=~2.41.2
+  - mount=~2.41.2
+  - umount=~2.41.2
+  - btrfs-progs=~6.17
+  - udev=~258.1
+  - util-linux-misc=~2.41.2 # contains fsck
+  - xfsprogs=~6.17.0
+  - xfsprogs-extra=~6.17.0 # contains xfs_io
+  - findmnt=~2.41.2
 
 accounts:
   run-as: root

--- a/cmd/stackit-csi-plugin/apko-base-image.yaml
+++ b/cmd/stackit-csi-plugin/apko-base-image.yaml
@@ -17,6 +17,7 @@ contents:
   - udev=~258.1
   - util-linux-misc=~2.41.2 # contains fsck
   - xfsprogs=~6.17.0
+  - xfsprogs-core=~6.17.0
   - xfsprogs-extra=~6.17.0 # contains xfs_io
   - findmnt=~2.41.2
 

--- a/cmd/stackit-csi-plugin/apko-base-image.yaml
+++ b/cmd/stackit-csi-plugin/apko-base-image.yaml
@@ -4,7 +4,7 @@ contents:
   repositories:
   - https://packages.wolfi.dev/os
   packages:
-  - busybox
+  - busybox # required by fsck.xfs as it is a sh script
   - ca-certificates=~20250911
   - blkid=~2.41.2
   - blockdev=~2.41.2

--- a/tools/csi-deps-check.sh
+++ b/tools/csi-deps-check.sh
@@ -30,6 +30,7 @@ set -o errexit
 /sbin/mke2fs -V
 /sbin/mkfs.ext4 -V
 /sbin/mkfs.xfs -V
+/usr/bin/fsck.xfs
 /usr/sbin/xfs_io -V # not used by mount-utils though
 /sbin/xfs_repair -V
 /usr/sbin/xfs_growfs -V


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

* Pin versions

Downgrades xfsprogs packages to  v6.17.0 from v6.18.0. v6.18 sets new defaults which are only available in Linux Kernel 6.10+

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
