### PR TITLE
Remove support for EOL kubernetes version 1.32

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,6 @@
     'release-v1.35',
     'release-v1.34',
     'release-v1.33',
-    'release-v1.32',
   ],
   customManagers: [
     {
@@ -103,16 +102,6 @@
         'release-v1.33',
       ],
       allowedVersions: '<0.34.0',
-      automerge: false,
-    },
-    {
-      matchPackageNames: [
-        '/^k8s.io/',
-      ],
-      matchBaseBranches: [
-        'release-v1.32',
-      ],
-      allowedVersions: '<0.33.0',
       automerge: false,
     },
     {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Does not include:
 - `readyz` and `healthz`
 - Kubernetes Client with self authorization by `inClusterConfig`
 
+## Version Compatibility
+
+The minor versions of `cloud-provider-stackit` are specifically aligned with the minor versions of `kubernetes/kubernetes`. To ensure compatibility, you must use the cloud provider release that matches your cluster's Kubernetes minor version.
+
+**Currently Supported Kubernetes Versions:**
+
+* `v1.33.x`
+* `v1.34.x`
+* `v1.35.x`
+
 ## User Documentation
 
 - Usage

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -6,6 +6,8 @@
 - [General Information](#general-information)
 - [Automated Release Process (Primary Method)](#automated-release-process-primary-method)
 - [Manual Release Process (Fallback Method)](#manual-release-process-fallback-method)
+- [Releasing a New Kubernetes Version](#releasing-a-new-kubernetes-version)
+- [Remove a old Kubernetes Version](#remove-a-old-kubernetes-version)
 
 ## Overview
 
@@ -54,3 +56,13 @@ Publishing a new release triggers the same Prow release job that builds and publ
 3. Create a new release branch `release-v1.XX` from `main`.
 4. Update the Renovate configuration via a PR against `main`: add the new release branch to `baseBranchPatterns` and add a new rule in `packageRules` for `/^k8s.io/`. Cherry-pick this PR to all maintained release branches. Example PR: https://github.com/stackitcloud/cloud-provider-stackit/pull/756
 5. Create a manual release for the new branch (note: the release tool will only work if there is already a tag on the branch). Do not generate release notes as they will contain many unrelated changes. Just add `Initial release of v1.xx.0` as release notes.
+6. Add the new version in the `README.md`.
+
+## Remove an Old Kubernetes Version
+
+If a Kubernetes version is EOL and it is not possible to create SKE clusters with that version, the support for Kubernetes version can be removed. 
+
+1. Release the version a last time (if there are changes).
+2. Remove the release branch in `.github/renovate.json5` under `baseBranchPatterns`.
+3. Remove the `packageRules` for the release branch in `.github/renovate.json5`.
+4. Remove the version from the `README.md`.


### PR DESCRIPTION
**How to categorize this PR?**

/kind cleanup

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/hold 
Hold until SKE removed the support for 1.32 (2026-04-15)

**What this PR does / why we need it**:

This removes support for the EOL kubernetes version `1.32`. This PR also adds docs how to remove support for an old kubernetes version.

After this PR is closed all open renovate PRs against `release-v1.32` can be closed. See [PRs](https://github.com/stackitcloud/cloud-provider-stackit/pulls?q=is%3Apr+is%3Aopen+release-v1.32).

