### PR TITLE
Refactor config

### DIFF
--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -52,10 +52,6 @@ type Instances struct {
 	region           string
 }
 
-type InstancesOpts struct {
-	API string `yaml:"api"`
-}
-
 func NewInstance(client stackit.NodeClient, projectID, region string) (*Instances, error) {
 	return &Instances{
 		iaasClient:       client,

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -47,7 +47,6 @@ type LoadBalancer struct {
 }
 
 type LoadBalancerOpts struct {
-	API         string            `yaml:"api"`
 	NetworkID   string            `yaml:"networkId"`
 	ExtraLabels map[string]string `yaml:"extraLabels"`
 }

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -42,14 +42,14 @@ type LoadBalancer struct {
 	client    stackit.LoadbalancerClient
 	recorder  record.EventRecorder // set in CloudControllerManager.Initialize
 	projectID string
-	opts      config.LoadBalancerOpts
+	opts      stackitconfig.LoadBalancerOpts
 	// metricsRemoteWrite setting this enables remote writing of metrics and nil means it is disabled
 	metricsRemoteWrite *MetricsRemoteWrite
 }
 
 var _ cloudprovider.LoadBalancer = (*LoadBalancer)(nil)
 
-func NewLoadBalancer(client stackit.LoadbalancerClient, projectID string, opts config.LoadBalancerOpts, metricsRemoteWrite *MetricsRemoteWrite) (*LoadBalancer, error) { //nolint:lll // looks weird when shortened
+func NewLoadBalancer(client stackit.LoadbalancerClient, projectID string, opts stackitconfig.LoadBalancerOpts, metricsRemoteWrite *MetricsRemoteWrite) (*LoadBalancer, error) { //nolint:lll // looks weird when shortened
 	// LoadBalancer.recorder is set in CloudControllerManager.Initialize
 	return &LoadBalancer{
 		client:             client,

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -41,19 +42,14 @@ type LoadBalancer struct {
 	client    stackit.LoadbalancerClient
 	recorder  record.EventRecorder // set in CloudControllerManager.Initialize
 	projectID string
-	opts      LoadBalancerOpts
+	opts      config.LoadBalancerOpts
 	// metricsRemoteWrite setting this enables remote writing of metrics and nil means it is disabled
 	metricsRemoteWrite *MetricsRemoteWrite
 }
 
-type LoadBalancerOpts struct {
-	NetworkID   string            `yaml:"networkId"`
-	ExtraLabels map[string]string `yaml:"extraLabels"`
-}
-
 var _ cloudprovider.LoadBalancer = (*LoadBalancer)(nil)
 
-func NewLoadBalancer(client stackit.LoadbalancerClient, projectID string, opts LoadBalancerOpts, metricsRemoteWrite *MetricsRemoteWrite) (*LoadBalancer, error) { //nolint:lll // looks weird when shortened
+func NewLoadBalancer(client stackit.LoadbalancerClient, projectID string, opts config.LoadBalancerOpts, metricsRemoteWrite *MetricsRemoteWrite) (*LoadBalancer, error) { //nolint:lll // looks weird when shortened
 	// LoadBalancer.recorder is set in CloudControllerManager.Initialize
 	return &LoadBalancer{
 		client:             client,

--- a/pkg/ccm/loadbalancer_spec.go
+++ b/pkg/ccm/loadbalancer_spec.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	corev1 "k8s.io/api/core/v1"
 
@@ -241,7 +242,7 @@ func getPlanID(service *corev1.Service) (planID *string, msgs []string, err erro
 func lbSpecFromService( //nolint:funlen,gocyclo // It is long but not complex.
 	service *corev1.Service,
 	nodes []*corev1.Node,
-	opts LoadBalancerOpts,
+	opts config.LoadBalancerOpts,
 	observability *loadbalancer.LoadbalancerOptionObservability,
 ) (*loadbalancer.CreateLoadBalancerPayload, []Event, error) {
 	lb := &loadbalancer.CreateLoadBalancerPayload{

--- a/pkg/ccm/loadbalancer_spec.go
+++ b/pkg/ccm/loadbalancer_spec.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	corev1 "k8s.io/api/core/v1"
 
@@ -242,7 +242,7 @@ func getPlanID(service *corev1.Service) (planID *string, msgs []string, err erro
 func lbSpecFromService( //nolint:funlen,gocyclo // It is long but not complex.
 	service *corev1.Service,
 	nodes []*corev1.Node,
-	opts config.LoadBalancerOpts,
+	opts stackitconfig.LoadBalancerOpts,
 	observability *loadbalancer.LoadbalancerOptionObservability,
 ) (*loadbalancer.CreateLoadBalancerPayload, []Event, error) {
 	lb := &loadbalancer.CreateLoadBalancerPayload{

--- a/pkg/ccm/loadbalancer_spec_test.go
+++ b/pkg/ccm/loadbalancer_spec_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +25,7 @@ var _ = Describe("lbSpecFromService", func() {
 		httpAlt corev1.ServicePort
 		https   corev1.ServicePort
 		dns     corev1.ServicePort
-		lbOpts  LoadBalancerOpts
+		lbOpts  stackitconfig.LoadBalancerOpts
 	)
 	BeforeEach(func() {
 		http = corev1.ServicePort{
@@ -47,7 +48,7 @@ var _ = Describe("lbSpecFromService", func() {
 			Port:     53,
 			Protocol: corev1.ProtocolUDP,
 		}
-		lbOpts = LoadBalancerOpts{NetworkID: "my-network"}
+		lbOpts = stackitconfig.LoadBalancerOpts{NetworkID: "my-network"}
 	})
 
 	Context("internal load balancer", func() {

--- a/pkg/ccm/loadbalancer_test.go
+++ b/pkg/ccm/loadbalancer_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -30,13 +31,13 @@ var _ = Describe("LoadBalancer", func() {
 		loadBalancer         *LoadBalancer
 		clusterName          string
 		projectID            string
-		lbOpts               LoadBalancerOpts
+		lbOpts               stackitconfig.LoadBalancerOpts
 	)
 
 	BeforeEach(func() {
 		clusterName = "my-cluster"
 		projectID = "my-project"
-		lbOpts = LoadBalancerOpts{NetworkID: "my-network"}
+		lbOpts = stackitconfig.LoadBalancerOpts{NetworkID: "my-network"}
 
 		ctrl := gomock.NewController(GinkgoT())
 		mockClient = stackit.NewMockLoadbalancerClient(ctrl)

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	sdkconfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
@@ -72,8 +72,8 @@ func init() {
 	})
 }
 
-func GetConfig(reader io.Reader) (config.CCMConfig, error) {
-	var cfg config.CCMConfig
+func GetConfig(reader io.Reader) (stackitconfig.CCMConfig, error) {
+	var cfg stackitconfig.CCMConfig
 
 	content, err := io.ReadAll(reader)
 	if err != nil {
@@ -117,8 +117,8 @@ func BuildObservability() (*MetricsRemoteWrite, error) {
 	return nil, fmt.Errorf("missing from env: %q", missingKeys)
 }
 
-// NewCloudControllerManager creates a new instance of the stackit struct from a config struct
-func NewCloudControllerManager(cfg *config.CCMConfig, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
+// NewCloudControllerManager creates a new instance of the stackit struct from a stackitconfig struct
+func NewCloudControllerManager(cfg *stackitconfig.CCMConfig, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
 	lbOpts := []sdkconfig.ConfigurationOption{
 		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
 	}

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	sdkconfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
@@ -19,7 +20,6 @@ import (
 
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/metrics"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 )
 
 const (
@@ -40,12 +40,6 @@ const (
 type CloudControllerManager struct {
 	loadBalancer *LoadBalancer
 	instances    *Instances
-}
-
-type Config struct {
-	Global       stackit.GlobalOpts `yaml:"global"`
-	Metadata     metadata.Opts      `yaml:"metadata"`
-	LoadBalancer LoadBalancerOpts   `yaml:"loadBalancer"`
 }
 
 func init() {
@@ -78,8 +72,8 @@ func init() {
 	})
 }
 
-func GetConfig(reader io.Reader) (Config, error) {
-	var cfg Config
+func GetConfig(reader io.Reader) (config.CCMConfig, error) {
+	var cfg config.CCMConfig
 
 	content, err := io.ReadAll(reader)
 	if err != nil {
@@ -124,7 +118,7 @@ func BuildObservability() (*MetricsRemoteWrite, error) {
 }
 
 // NewCloudControllerManager creates a new instance of the stackit struct from a config struct
-func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
+func NewCloudControllerManager(cfg *config.CCMConfig, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
 	lbOpts := []sdkconfig.ConfigurationOption{
 		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
 	}

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -46,7 +46,6 @@ type Config struct {
 	Global       stackit.GlobalOpts `yaml:"global"`
 	Metadata     metadata.Opts      `yaml:"metadata"`
 	LoadBalancer LoadBalancerOpts   `yaml:"loadBalancer"`
-	Instances    InstancesOpts      `yaml:"instances"`
 }
 
 func init() {
@@ -130,15 +129,15 @@ func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudCont
 		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
 	}
 
-	if cfg.LoadBalancer.API != "" {
-		lbOpts = append(lbOpts, sdkconfig.WithEndpoint(cfg.LoadBalancer.API))
+	if cfg.Global.APIEndpoints.LoadBalancerAPI != "" {
+		lbOpts = append(lbOpts, sdkconfig.WithEndpoint(cfg.Global.APIEndpoints.LoadBalancerAPI))
 	}
 
 	// The token is only provided by the 'gardener-extension-provider-stackit' in case of emergency access.
 	// In those cases, the [cfg.LoadBalancerAPI.URL] will also be different (direct API URL instead of the API Gateway)
 	lbEmergencyAPIToken := os.Getenv(stackitLoadBalancerEmergencyAPIToken)
 	if lbEmergencyAPIToken != "" {
-		klog.Warningf("Using emergency token for loadbalancer api on host: %s", cfg.LoadBalancer.API)
+		klog.Warningf("Using emergency token for loadbalancer api on host: %s", cfg.Global.APIEndpoints.LoadBalancerAPI)
 		lbOpts = append(lbOpts, sdkconfig.WithToken(lbEmergencyAPIToken))
 	}
 
@@ -155,8 +154,8 @@ func NewCloudControllerManager(cfg *Config, obs *MetricsRemoteWrite) (*CloudCont
 		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
 	}
 
-	if cfg.Instances.API != "" {
-		iaasOpts = append(iaasOpts, sdkconfig.WithEndpoint(cfg.Instances.API))
+	if cfg.Global.APIEndpoints.IaasAPI != "" {
+		iaasOpts = append(iaasOpts, sdkconfig.WithEndpoint(cfg.Global.APIEndpoints.IaasAPI))
 	}
 
 	iaasInnerClient, err := iaas.NewAPIClient(iaasOpts...)

--- a/pkg/ccm/stackit_test.go
+++ b/pkg/ccm/stackit_test.go
@@ -14,10 +14,11 @@ var _ = Describe("GetConfig", func() {
 global:
   projectId: "test-project"
   region: "eu01"
+  apiEndpoints:
+    loadBalancerApi: "https://load-balancer.api.eu01.stackit.cloud"
 metadata:
   searchOrder: "metadataService,configDrive"
 loadBalancer:
-  api: "https://load-balancer.api.eu01.stackit.cloud"
   networkId: "test-network"
 `
 
@@ -25,8 +26,8 @@ loadBalancer:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(config.Global.ProjectID).To(Equal("test-project"))
 		Expect(config.Global.Region).To(Equal("eu01"))
+		Expect(config.Global.APIEndpoints.LoadBalancerAPI).To(Equal("https://load-balancer.api.eu01.stackit.cloud"))
 		Expect(config.Metadata.SearchOrder).To(Equal("metadataService,configDrive"))
-		Expect(config.LoadBalancer.API).To(Equal("https://load-balancer.api.eu01.stackit.cloud"))
 		Expect(config.LoadBalancer.NetworkID).To(Equal("test-network"))
 	})
 
@@ -43,8 +44,8 @@ loadBalancer:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(config.Global.ProjectID).To(Equal("my-project"))
 		Expect(config.Global.Region).To(Equal("eu01"))
+		Expect(config.Global.APIEndpoints.LoadBalancerAPI).To(BeEmpty())
 		Expect(config.LoadBalancer.NetworkID).To(Equal("my-network"))
-		Expect(config.LoadBalancer.API).To(BeEmpty())
 	})
 
 	It("should handle configuration with extra labels", func() {

--- a/pkg/ccm/stackit_test.go
+++ b/pkg/ccm/stackit_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 )
 
 var _ = Describe("GetConfig", func() {
@@ -83,7 +84,7 @@ global:
 
 		config, err := GetConfig(strings.NewReader(emptyYAML))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(config).To(Equal(Config{}))
+		Expect(config).To(Equal(stackitconfig.CCMConfig{}))
 	})
 
 	It("should return error for invalid YAML structure", func() {
@@ -134,6 +135,6 @@ loadBalancer:
 
 		config, err := GetConfig(emptyReader)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(config).To(Equal(Config{}))
+		Expect(config).To(Equal(stackitconfig.CCMConfig{}))
 	})
 })

--- a/pkg/csi/blockstorage/driver.go
+++ b/pkg/csi/blockstorage/driver.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	corev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
@@ -138,7 +139,7 @@ func (d *Driver) SetupControllerService(instance stackit.IaasClient) {
 	d.cs = NewControllerServer(d, instance)
 }
 
-func (d *Driver) SetupNodeService(mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackit.BlockStorageOpts) {
+func (d *Driver) SetupNodeService(mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts config.BlockStorageOpts) {
 	klog.Info("Providing node service")
 	d.ns = NewNodeServer(d, mountProvider, metadataProvider, opts)
 }

--- a/pkg/csi/blockstorage/driver.go
+++ b/pkg/csi/blockstorage/driver.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	corev1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
@@ -139,7 +139,7 @@ func (d *Driver) SetupControllerService(instance stackit.IaasClient) {
 	d.cs = NewControllerServer(d, instance)
 }
 
-func (d *Driver) SetupNodeService(mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts config.BlockStorageOpts) {
+func (d *Driver) SetupNodeService(mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackitconfig.BlockStorageOpts) {
 	klog.Info("Providing node service")
 	d.ns = NewNodeServer(d, mountProvider, metadataProvider, opts)
 }

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -26,7 +26,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi/util"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -43,7 +43,7 @@ type nodeServer struct {
 	Driver   *Driver
 	Mount    mount.IMount
 	Metadata metadata.IMetadata
-	Opts     config.BlockStorageOpts
+	Opts     stackitconfig.BlockStorageOpts
 	csi.UnimplementedNodeServer
 }
 

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi/util"
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -35,7 +36,6 @@ import (
 	sharedcsi "github.com/stackitcloud/cloud-provider-stackit/pkg/csi"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi/util/blockdevice"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi/util/mount"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 )
 
@@ -43,7 +43,7 @@ type nodeServer struct {
 	Driver   *Driver
 	Mount    mount.IMount
 	Metadata metadata.IMetadata
-	Opts     stackit.BlockStorageOpts
+	Opts     config.BlockStorageOpts
 	csi.UnimplementedNodeServer
 }
 

--- a/pkg/csi/blockstorage/nodeserver_test.go
+++ b/pkg/csi/blockstorage/nodeserver_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,7 +42,7 @@ var _ = Describe("NodeServer", func() {
 			d,
 			mountMock,
 			metadataMock,
-			stackit.BlockStorageOpts{},
+			stackitconfig.BlockStorageOpts{},
 		)
 	})
 

--- a/pkg/csi/blockstorage/sanity_test.go
+++ b/pkg/csi/blockstorage/sanity_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kubernetes-csi/csi-test/v5/pkg/sanity"
 	. "github.com/onsi/ginkgo/v2"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	mountutils "k8s.io/mount-utils"
 	exec "k8s.io/utils/exec/testing"
 
@@ -437,7 +438,7 @@ var _ = Describe("CSI sanity test", Ordered, func() {
 
 			// --- Driver Setup & Run ---
 			driver.SetupControllerService(iaasClient)
-			driver.SetupNodeService(mountMock, metadataMock, stackit.BlockStorageOpts{})
+			driver.SetupNodeService(mountMock, metadataMock, stackitconfig.BlockStorageOpts{})
 
 			go func() {
 				defer GinkgoRecover()

--- a/pkg/csi/blockstorage/utils.go
+++ b/pkg/csi/blockstorage/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi/util/mount"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -56,7 +57,7 @@ func NewIdentityServer(d *Driver) *identityServer {
 	}
 }
 
-func NewNodeServer(d *Driver, mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackit.BlockStorageOpts) *nodeServer { //nolint:lll // looks weird when shortened
+func NewNodeServer(d *Driver, mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts config.BlockStorageOpts) *nodeServer { //nolint:lll // looks weird when shortened
 	return &nodeServer{
 		Driver:   d,
 		Mount:    mountProvider,

--- a/pkg/csi/blockstorage/utils.go
+++ b/pkg/csi/blockstorage/utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi/util/mount"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -57,7 +57,7 @@ func NewIdentityServer(d *Driver) *identityServer {
 	}
 }
 
-func NewNodeServer(d *Driver, mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts config.BlockStorageOpts) *nodeServer { //nolint:lll // looks weird when shortened
+func NewNodeServer(d *Driver, mountProvider mount.IMount, metadataProvider metadata.IMetadata, opts stackitconfig.BlockStorageOpts) *nodeServer { //nolint:lll // looks weird when shortened
 	return &nodeServer{
 		Driver:   d,
 		Mount:    mountProvider,

--- a/pkg/stackit/backups_test.go
+++ b/pkg/stackit/backups_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ var _ = Describe("Backup", func() {
 		mockCtrl  *gomock.Controller
 		mockAPI   *mock.MockDefaultApi
 		openStack IaasClient
-		config    *Config
+		config    *stackitconfig.CSIConfig
 	)
 
 	const projectID = "project-id"
@@ -34,8 +35,8 @@ var _ = Describe("Backup", func() {
 
 	Context("CreateBackup", func() {
 		BeforeEach(func() {
-			config = &Config{
-				Global: GlobalOpts{
+			config = &stackitconfig.CSIConfig{
+				Global: stackitconfig.GlobalOpts{
 					ProjectID: projectID,
 				},
 			}
@@ -97,8 +98,8 @@ var _ = Describe("Backup", func() {
 		const projectID = "project-id"
 
 		BeforeEach(func() {
-			config = &Config{
-				Global: GlobalOpts{
+			config = &stackitconfig.CSIConfig{
+				Global: stackitconfig.GlobalOpts{
 					ProjectID: projectID,
 				},
 			}
@@ -131,8 +132,8 @@ var _ = Describe("Backup", func() {
 		const projectID = "project-id"
 
 		BeforeEach(func() {
-			config = &Config{
-				Global: GlobalOpts{
+			config = &stackitconfig.CSIConfig{
+				Global: stackitconfig.GlobalOpts{
 					ProjectID: projectID,
 				},
 			}
@@ -183,8 +184,8 @@ var _ = Describe("Backup", func() {
 		const projectID = "project-id"
 
 		BeforeEach(func() {
-			config = &Config{
-				Global: GlobalOpts{
+			config = &stackitconfig.CSIConfig{
+				Global: stackitconfig.GlobalOpts{
 					ProjectID: projectID,
 				},
 			}

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	sdkconfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	oapiError "github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
@@ -36,8 +37,6 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
-
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 )
 
 // userAgentData is used to add extra information to the STACKIT SDK user-agent
@@ -75,7 +74,7 @@ type IaasClient interface {
 	WaitBackupReady(ctx context.Context, backupID string, snapshotSize int64, backupMaxDurationSecondsPerGB int) (*string, error)
 	GetInstanceByID(ctx context.Context, instanceID string) (*iaas.Server, error)
 	ExpandVolume(ctx context.Context, volumeID string, status string, size int64) error
-	GetBlockStorageOpts() BlockStorageOpts
+	GetBlockStorageOpts() config.BlockStorageOpts
 	WaitVolumeTargetStatusWithCustomBackoff(ctx context.Context, volumeID string, targetStatus []string, backoff *wait.Backoff) error
 }
 
@@ -107,7 +106,7 @@ type iaasClient struct {
 	iaas      iaas.DefaultApi
 	projectID string
 	region    string
-	bsOpts    BlockStorageOpts
+	bsOpts    config.BlockStorageOpts
 }
 
 type lbClient struct {
@@ -120,33 +119,12 @@ type nodeClient struct {
 }
 
 //nolint:gocritic // The openstack package currently shadows but will be renamed anyway.
-func (os *iaasClient) GetBlockStorageOpts() BlockStorageOpts {
+func (os *iaasClient) GetBlockStorageOpts() config.BlockStorageOpts {
 	return os.bsOpts
 }
 
-type BlockStorageOpts struct {
-	RescanOnResize bool `yaml:"rescanOnResize"`
-}
-
-type GlobalOpts struct {
-	ProjectID    string       `yaml:"projectId"`
-	Region       string       `yaml:"region"`
-	APIEndpoints APIEndpoints `yaml:"apiEndpoints"`
-}
-
-type APIEndpoints struct {
-	IaasAPI         string `yaml:"iaasApi"`
-	LoadBalancerAPI string `yaml:"loadBalancerApi"`
-}
-
-type Config struct {
-	Global       GlobalOpts       `yaml:"global"`
-	Metadata     metadata.Opts    `yaml:"metadata"`
-	BlockStorage BlockStorageOpts `yaml:"blockStorage"`
-}
-
-func GetConfig(reader io.Reader) (Config, error) {
-	var cfg Config
+func GetConfig(reader io.Reader) (config.CSIConfig, error) {
+	var cfg config.CSIConfig
 
 	content, err := io.ReadAll(reader)
 	if err != nil {
@@ -163,8 +141,8 @@ func GetConfig(reader io.Reader) (Config, error) {
 	return cfg, nil
 }
 
-func GetConfigFromFile(path string) (Config, error) {
-	var cfg Config
+func GetConfigFromFile(path string) (config.CSIConfig, error) {
+	var cfg config.CSIConfig
 
 	config, err := os.Open(path)
 	if err != nil {
@@ -177,7 +155,7 @@ func GetConfigFromFile(path string) (Config, error) {
 }
 
 // CreateSTACKITProvider creates STACKIT Instance
-func CreateSTACKITProvider(client iaas.DefaultApi, cfg *Config) (IaasClient, error) {
+func CreateSTACKITProvider(client iaas.DefaultApi, cfg *config.CSIConfig) (IaasClient, error) {
 	region := os.Getenv("STACKIT_REGION")
 	if region == "" {
 		panic("STACKIT_REGION environment variable not set")
@@ -193,7 +171,7 @@ func CreateSTACKITProvider(client iaas.DefaultApi, cfg *Config) (IaasClient, err
 	return instance, nil
 }
 
-func CreateIaaSClient(cfg *Config) (iaas.DefaultApi, error) {
+func CreateIaaSClient(cfg *config.CSIConfig) (iaas.DefaultApi, error) {
 	var userAgent []string
 	var opts []sdkconfig.ConfigurationOption
 	userAgent = append(userAgent, fmt.Sprintf("%s/%s", "block-storage-csi-driver", version.Version))

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	sdkconfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	oapiError "github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
@@ -74,7 +74,7 @@ type IaasClient interface {
 	WaitBackupReady(ctx context.Context, backupID string, snapshotSize int64, backupMaxDurationSecondsPerGB int) (*string, error)
 	GetInstanceByID(ctx context.Context, instanceID string) (*iaas.Server, error)
 	ExpandVolume(ctx context.Context, volumeID string, status string, size int64) error
-	GetBlockStorageOpts() config.BlockStorageOpts
+	GetBlockStorageOpts() stackitconfig.BlockStorageOpts
 	WaitVolumeTargetStatusWithCustomBackoff(ctx context.Context, volumeID string, targetStatus []string, backoff *wait.Backoff) error
 }
 
@@ -106,7 +106,7 @@ type iaasClient struct {
 	iaas      iaas.DefaultApi
 	projectID string
 	region    string
-	bsOpts    config.BlockStorageOpts
+	bsOpts    stackitconfig.BlockStorageOpts
 }
 
 type lbClient struct {
@@ -119,12 +119,12 @@ type nodeClient struct {
 }
 
 //nolint:gocritic // The openstack package currently shadows but will be renamed anyway.
-func (os *iaasClient) GetBlockStorageOpts() config.BlockStorageOpts {
+func (os *iaasClient) GetBlockStorageOpts() stackitconfig.BlockStorageOpts {
 	return os.bsOpts
 }
 
-func GetConfig(reader io.Reader) (config.CSIConfig, error) {
-	var cfg config.CSIConfig
+func GetConfig(reader io.Reader) (stackitconfig.CSIConfig, error) {
+	var cfg stackitconfig.CSIConfig
 
 	content, err := io.ReadAll(reader)
 	if err != nil {
@@ -141,12 +141,12 @@ func GetConfig(reader io.Reader) (config.CSIConfig, error) {
 	return cfg, nil
 }
 
-func GetConfigFromFile(path string) (config.CSIConfig, error) {
-	var cfg config.CSIConfig
+func GetConfigFromFile(path string) (stackitconfig.CSIConfig, error) {
+	var cfg stackitconfig.CSIConfig
 
 	config, err := os.Open(path)
 	if err != nil {
-		klog.ErrorS(err, "Failed to open config file", "path", path)
+		klog.ErrorS(err, "Failed to open stackitconfig file", "path", path)
 		return cfg, err
 	}
 	defer config.Close()
@@ -155,7 +155,7 @@ func GetConfigFromFile(path string) (config.CSIConfig, error) {
 }
 
 // CreateSTACKITProvider creates STACKIT Instance
-func CreateSTACKITProvider(client iaas.DefaultApi, cfg *config.CSIConfig) (IaasClient, error) {
+func CreateSTACKITProvider(client iaas.DefaultApi, cfg *stackitconfig.CSIConfig) (IaasClient, error) {
 	region := os.Getenv("STACKIT_REGION")
 	if region == "" {
 		panic("STACKIT_REGION environment variable not set")
@@ -171,7 +171,7 @@ func CreateSTACKITProvider(client iaas.DefaultApi, cfg *config.CSIConfig) (IaasC
 	return instance, nil
 }
 
-func CreateIaaSClient(cfg *config.CSIConfig) (iaas.DefaultApi, error) {
+func CreateIaaSClient(cfg *stackitconfig.CSIConfig) (iaas.DefaultApi, error) {
 	var userAgent []string
 	var opts []sdkconfig.ConfigurationOption
 	userAgent = append(userAgent, fmt.Sprintf("%s/%s", "block-storage-csi-driver", version.Version))

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -129,9 +129,14 @@ type BlockStorageOpts struct {
 }
 
 type GlobalOpts struct {
-	ProjectID string `yaml:"projectId"`
-	IaasAPI   string `yaml:"iaasApi"`
-	Region    string `yaml:"region"`
+	ProjectID    string       `yaml:"projectId"`
+	Region       string       `yaml:"region"`
+	APIEndpoints APIEndpoints `yaml:"apiEndpoints"`
+}
+
+type APIEndpoints struct {
+	IaasAPI         string `yaml:"iaasApi"`
+	LoadBalancerAPI string `yaml:"loadBalancerApi"`
 }
 
 type Config struct {
@@ -198,8 +203,8 @@ func CreateIaaSClient(cfg *Config) (iaas.DefaultApi, error) {
 	}
 	klog.V(4).Infof("Using user-agent: %s", userAgent)
 
-	if cfg.Global.IaasAPI != "" {
-		opts = append(opts, sdkconfig.WithEndpoint(cfg.Global.IaasAPI))
+	if cfg.Global.APIEndpoints.IaasAPI != "" {
+		opts = append(opts, sdkconfig.WithEndpoint(cfg.Global.APIEndpoints.IaasAPI))
 	}
 
 	opts = append(opts, sdkconfig.WithUserAgent(strings.Join(userAgent, " ")))

--- a/pkg/stackit/client_test.go
+++ b/pkg/stackit/client_test.go
@@ -8,7 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 )
 
@@ -32,7 +32,7 @@ blockStorage:
 				SearchOrder:    "configDrive,metadataService",
 				RequestTimeout: metadata.Duration{Duration: 5 * time.Second},
 			}))
-			Expect(cfg.BlockStorage).To(Equal(config.BlockStorageOpts{
+			Expect(cfg.BlockStorage).To(Equal(stackitconfig.BlockStorageOpts{
 				RescanOnResize: true,
 			}))
 			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
@@ -65,7 +65,7 @@ global:
 			cfg, err := GetConfig(strings.NewReader(``))
 			Expect(err).NotTo(HaveOccurred())
 			// Empty YAML should result in zero values
-			Expect(cfg).To(Equal(config.CSIConfig{}))
+			Expect(cfg).To(Equal(stackitconfig.CSIConfig{}))
 		})
 	})
 
@@ -75,7 +75,7 @@ global:
 
 		BeforeEach(func() {
 			var err error
-			tempFile, err = os.CreateTemp("", "test-config-*.yaml")
+			tempFile, err = os.CreateTemp("", "test-stackitconfig-*.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			tempFilePath = tempFile.Name()
 		})

--- a/pkg/stackit/client_test.go
+++ b/pkg/stackit/client_test.go
@@ -19,6 +19,8 @@ global:
   projectId: "test-project"
   iaasApi: "https://api.example.com"
   region: "eu01"
+  apiEndpoints:
+    iaasApi: "https://api.example.com"
 metadata:
   searchOrder: "configDrive,metadataService"
   requestTimeout: "5s"
@@ -34,7 +36,7 @@ blockStorage:
 			}))
 			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
 			Expect(cfg.Global.Region).To(Equal("eu01"))
-			Expect(cfg.Global.IaasAPI).To(Equal("https://api.example.com"))
+			Expect(cfg.Global.APIEndpoints.IaasAPI).To(Equal("https://api.example.com"))
 		})
 
 		It("should handle missing optional fields", func() {
@@ -46,7 +48,7 @@ global:
 			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
 			Expect(cfg.Global.Region).To(Equal("eu01"))
 			// Optional fields should be empty/zero values
-			Expect(cfg.Global.IaasAPI).To(BeEmpty())
+			Expect(cfg.Global.APIEndpoints.IaasAPI).To(BeEmpty())
 		})
 
 		It("should return error for invalid yaml", func() {

--- a/pkg/stackit/client_test.go
+++ b/pkg/stackit/client_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 )
 
@@ -31,7 +32,7 @@ blockStorage:
 				SearchOrder:    "configDrive,metadataService",
 				RequestTimeout: metadata.Duration{Duration: 5 * time.Second},
 			}))
-			Expect(cfg.BlockStorage).To(Equal(BlockStorageOpts{
+			Expect(cfg.BlockStorage).To(Equal(config.BlockStorageOpts{
 				RescanOnResize: true,
 			}))
 			Expect(cfg.Global.ProjectID).To(Equal("test-project"))
@@ -64,7 +65,7 @@ global:
 			cfg, err := GetConfig(strings.NewReader(``))
 			Expect(err).NotTo(HaveOccurred())
 			// Empty YAML should result in zero values
-			Expect(cfg).To(Equal(Config{}))
+			Expect(cfg).To(Equal(config.CSIConfig{}))
 		})
 	})
 

--- a/pkg/stackit/config/config.go
+++ b/pkg/stackit/config/config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
+)
+
+type GlobalOpts struct {
+	ProjectID    string       `yaml:"projectId"`
+	Region       string       `yaml:"region"`
+	APIEndpoints APIEndpoints `yaml:"apiEndpoints"`
+}
+
+type APIEndpoints struct {
+	IaasAPI         string `yaml:"iaasApi"`
+	LoadBalancerAPI string `yaml:"loadBalancerApi"`
+}
+
+type CCMConfig struct {
+	Global       GlobalOpts       `yaml:"global"`
+	Metadata     metadata.Opts    `yaml:"metadata"`
+	LoadBalancer LoadBalancerOpts `yaml:"loadBalancer"`
+}
+
+type LoadBalancerOpts struct {
+	NetworkID   string            `yaml:"networkId"`
+	ExtraLabels map[string]string `yaml:"extraLabels"`
+}
+
+type CSIConfig struct {
+	Global       GlobalOpts       `yaml:"global"`
+	Metadata     metadata.Opts    `yaml:"metadata"`
+	BlockStorage BlockStorageOpts `yaml:"blockStorage"`
+}
+
+type BlockStorageOpts struct {
+	RescanOnResize bool `yaml:"rescanOnResize"`
+}

--- a/pkg/stackit/iaas_mock.go
+++ b/pkg/stackit/iaas_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	config "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	gomock "go.uber.org/mock/gomock"
 	wait "k8s.io/apimachinery/pkg/util/wait"
@@ -188,10 +189,10 @@ func (mr *MockIaasClientMockRecorder) GetBackupByID(ctx, backupID any) *gomock.C
 }
 
 // GetBlockStorageOpts mocks base method.
-func (m *MockIaasClient) GetBlockStorageOpts() BlockStorageOpts {
+func (m *MockIaasClient) GetBlockStorageOpts() config.BlockStorageOpts {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockStorageOpts")
-	ret0, _ := ret[0].(BlockStorageOpts)
+	ret0, _ := ret[0].(config.BlockStorageOpts)
 	return ret0
 }
 

--- a/pkg/stackit/snapshots_test.go
+++ b/pkg/stackit/snapshots_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	stackitconfig "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"go.uber.org/mock/gomock"
 
@@ -18,7 +19,7 @@ var _ = Describe("Snapshot", func() {
 		mockCtrl      *gomock.Controller
 		mockAPI       *mock.MockDefaultApi
 		stackitClient IaasClient
-		config        *Config
+		config        *stackitconfig.CSIConfig
 	)
 	const projectID = "project-id"
 	const region = "eu01"
@@ -57,8 +58,8 @@ var _ = Describe("Snapshot", func() {
 		}
 
 		BeforeEach(func() {
-			config = &Config{
-				Global: GlobalOpts{
+			config = &stackitconfig.CSIConfig{
+				Global: stackitconfig.GlobalOpts{
 					ProjectID: projectID,
 				},
 			}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup
/kind enhancement

/cc @stackitcloud/ske-infrastructure 

**What this PR does / why we need it**:

This PR refactors the config of the CSI and CCM. There were multiple fields for the IaaS API endpoint, there is now a dedicated `apiEndpoints` field in the global config. Additional in preparation for the ALB Integration (#879) the config is now in a dedicated package.

**Special notes for your reviewer**:

**Breaking changes**:

/label breaking

The API Endpoints are now in a dedicated field. This can be not used by external customers but this needs adoption `gardener-extension-provider-stackit`.

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
