### PR TITLE
WIP: Check actual volume size after volume expand to verify if expand…

### DIFF
--- a/pkg/csi/blockstorage/controllerserver.go
+++ b/pkg/csi/blockstorage/controllerserver.go
@@ -947,10 +947,10 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 	// we need wait for the volume to be available or InUse, it might be error_extending in some scenario
 	targetStatus := []string{stackit.VolumeAvailableStatus, stackit.VolumeAttachedStatus}
-	err = cloud.WaitVolumeTargetStatus(ctx, volumeID, targetStatus)
+	err = cloud.WaitVolumeTargetStatus(ctx, volumeID, targetStatus, volSizeGB)
 	if err != nil {
 		klog.Errorf("Failed to WaitVolumeTargetStatus of volume %s: %v", volumeID, err)
-		return nil, status.Errorf(codes.Internal, "[ControllerExpandVolume] Volume %s not in target state after resize operation: %v", volumeID, err)
+		return nil, status.Errorf(codes.Internal, "[ControllerExpandVolume] Volume %s not in target state or size after resize operation: %v", volumeID, err)
 	}
 
 	klog.V(4).Infof("ControllerExpandVolume resized volume %v to size %v", volumeID, volSizeGB)

--- a/pkg/stackit/client.go
+++ b/pkg/stackit/client.go
@@ -58,7 +58,7 @@ type IaasClient interface {
 	WaitDiskAttached(ctx context.Context, instanceID string, volumeID string) error
 	DetachVolume(ctx context.Context, instanceID, volumeID string) error
 	WaitDiskDetached(ctx context.Context, instanceID string, volumeID string) error
-	WaitVolumeTargetStatus(ctx context.Context, volumeID string, tStatus []string) error
+	WaitVolumeTargetStatus(ctx context.Context, volumeID string, tStatus []string, tSize int64) error
 	GetVolume(ctx context.Context, volumeID string) (*iaas.Volume, error)
 	GetVolumesByName(ctx context.Context, name string) ([]iaas.Volume, error)
 	GetVolumeByName(ctx context.Context, name string) (*iaas.Volume, error)

--- a/pkg/stackit/iaas_mock.go
+++ b/pkg/stackit/iaas_mock.go
@@ -383,7 +383,7 @@ func (mr *MockIaasClientMockRecorder) WaitSnapshotReady(ctx, snapshotID any) *go
 }
 
 // WaitVolumeTargetStatus mocks base method.
-func (m *MockIaasClient) WaitVolumeTargetStatus(ctx context.Context, volumeID string, tStatus []string) error {
+func (m *MockIaasClient) WaitVolumeTargetStatus(ctx context.Context, volumeID string, tStatus []string, tSize int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitVolumeTargetStatus", ctx, volumeID, tStatus)
 	ret0, _ := ret[0].(error)

--- a/pkg/stackit/volumes.go
+++ b/pkg/stackit/volumes.go
@@ -292,11 +292,23 @@ func (os *iaasClient) GetVolumeByName(ctx context.Context, name string) (*iaas.V
 	return &vols[0], nil
 }
 
-func (os *iaasClient) WaitVolumeTargetStatus(ctx context.Context, volumeID string, tStatus []string) error {
+func (os *iaasClient) WaitVolumeTargetStatus(ctx context.Context, volumeID string, tStatus []string, tSize int64) error {
 	backoff := wait.Backoff{
 		Duration: operationFinishInitDelay,
 		Factor:   operationFinishFactor,
 		Steps:    operationFinishSteps,
+	}
+
+	// volResizeSuccess checks if the volume is an "GOOD" State and the target Size has
+	// been met.
+	volResizeSuccess := func(vol *iaas.Volume, tSize int64, tStatus []string) bool {
+		if slices.Contains(tStatus, *vol.Status) {
+			if tSize == vol.GetSize() {
+				return true
+			}
+			return false
+		}
+		return false
 	}
 
 	waitErr := wait.ExponentialBackoff(backoff, func() (bool, error) {
@@ -304,7 +316,8 @@ func (os *iaasClient) WaitVolumeTargetStatus(ctx context.Context, volumeID strin
 		if err != nil {
 			return false, err
 		}
-		if slices.Contains(tStatus, *vol.Status) {
+		// Check status
+		if volResizeSuccess(vol, tSize, tStatus) {
 			return true, nil
 		}
 		for _, eState := range volumeErrorStates {


### PR DESCRIPTION
… was successful

**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

Problem mitigation. This also happens on the openstack CSI.

The problem is that the expand is **async** and therefore later-on can be rejected (due to i.e. storage policies), while still pretending to been have successful. This check checks the actual volume size and then reports an error. Additionally it also retries.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
