### PR TITLE
Fix golangci lint url

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,6 +42,9 @@ linters:
     goconst:
       min-len: 2
       min-occurrences: 5
+      ignore-string-values:
+        - 'true'
+        - 'false'
     gocritic:
       disabled-checks:
         - dupImport

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -39,7 +39,7 @@ $(GOIMPORTS_REVISER): $(call tool_version_file,$(GOIMPORTS_REVISER),$(GOIMPORTS_
 
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERSION))
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VERSION)
 
 MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
 $(MOCKGEN): $(call tool_version_file,$(MOCKGEN),$(MOCKGEN_VERSION))

--- a/pkg/ccm/loadbalancer_spec.go
+++ b/pkg/ccm/loadbalancer_spec.go
@@ -68,133 +68,137 @@ const (
 
 const eventReasonYawolAnnotationPresent = "YawolAnnotationPresent"
 
-var availablePlanIDs = []string{"p10", "p50", "p250", "p750"}
+const (
+	p10  = "p10"
+	p50  = "p50"
+	p250 = "p250"
+	p750 = "p750"
+)
 
-// the default plan ID when no plan ID annotation is found
-var defaultServicePlan = "p10"
+var availablePlanIDs = []string{p10, p50, p250, p750}
 
 var flavorsMap = map[string]string{
-	"85f57dd5-712b-489d-a0e3-4898c3962930": "p10",  // t1.2
-	"cd49f4fd-1e48-497f-91ad-79894c8b95e4": "p50",  // s1a.4d
-	"72f11e14-2825-471d-a237-b1afa775fdad": "p250", // s1a.8d
-	"53408825-7086-48c2-9126-cafdeb2d35d6": "p750", // s1a.16d
+	"85f57dd5-712b-489d-a0e3-4898c3962930": p10,  // t1.2
+	"cd49f4fd-1e48-497f-91ad-79894c8b95e4": p50,  // s1a.4d
+	"72f11e14-2825-471d-a237-b1afa775fdad": p250, // s1a.8d
+	"53408825-7086-48c2-9126-cafdeb2d35d6": p750, // s1a.16d
 }
 
 var appoximateFlavorsMap = map[string]string{
-	"2faeefeb-efe7-4f8b-9e52-3246a5d709f0": "p50",  // s1a.2d
-	"9b6bfa7b-bb80-4da8-aa10-ddd4cfaaa1a1": "p750", // s1a.32d
-	"8936d6a5-30bb-4012-834c-29c599800e53": "p750", // s1a.60d
+	"2faeefeb-efe7-4f8b-9e52-3246a5d709f0": p50,  // s1a.2d
+	"9b6bfa7b-bb80-4da8-aa10-ddd4cfaaa1a1": p750, // s1a.32d
+	"8936d6a5-30bb-4012-834c-29c599800e53": p750, // s1a.60d
 
-	"75e8134a-e1de-4052-b3be-75c5157c47c6": "p250", // b1.1
-	"1493fabc-3e5c-4992-82fc-d43e2c33902a": "p750", // b1.2
-	"f77046c4-6c41-452c-9983-7264151252fa": "p750", // b1.3
-	"f778f21f-b0a7-4ae0-88e9-917f01d6fb52": "p750", // b1.4
+	"75e8134a-e1de-4052-b3be-75c5157c47c6": p250, // b1.1
+	"1493fabc-3e5c-4992-82fc-d43e2c33902a": p750, // b1.2
+	"f77046c4-6c41-452c-9983-7264151252fa": p750, // b1.3
+	"f778f21f-b0a7-4ae0-88e9-917f01d6fb52": p750, // b1.4
 
-	"49902b99-b428-4e6a-ad34-d8b9e719390f": "p250", // b1a.1d
-	"ce99338f-afc2-4966-89e2-34e494d89e4b": "p750", // b1a.2d
-	"2e364c23-ee61-451c-841c-8fa25573ae9d": "p750", // b1a.4d
-	"c1e2def6-e182-4bf6-a0f9-9b5b453eb55a": "p750", // b1a.8d
-	"fda4f402-6d43-4db5-bcf1-384596f237bb": "p750", // b1a.16d
-	"704c07a3-1308-4cdd-b8f3-0892589cb99c": "p750", // b1a.32d
-	"696d8b7a-6aaa-456c-853b-11a7ba490b66": "p750", // b1a.60d
-	"8b46ca04-e7ec-4f01-a2ed-67e75e3fe04f": "p750", // b1a.120d
+	"49902b99-b428-4e6a-ad34-d8b9e719390f": p250, // b1a.1d
+	"ce99338f-afc2-4966-89e2-34e494d89e4b": p750, // b1a.2d
+	"2e364c23-ee61-451c-841c-8fa25573ae9d": p750, // b1a.4d
+	"c1e2def6-e182-4bf6-a0f9-9b5b453eb55a": p750, // b1a.8d
+	"fda4f402-6d43-4db5-bcf1-384596f237bb": p750, // b1a.16d
+	"704c07a3-1308-4cdd-b8f3-0892589cb99c": p750, // b1a.32d
+	"696d8b7a-6aaa-456c-853b-11a7ba490b66": p750, // b1a.60d
+	"8b46ca04-e7ec-4f01-a2ed-67e75e3fe04f": p750, // b1a.120d
 
-	"882a98ba-d47f-4a52-bd85-ccbc2b08f8f8": "p250", // b2i.1d
-	"6c1b79d7-b344-407e-808d-476187c7dcd6": "p750", // b2i.2d
-	"013451f5-4c26-4464-84e6-cc5f1c8b0f8a": "p750", // b2i.4d
-	"2787f539-a8b9-40d3-873d-6db51a2edb41": "p750", // b2i.8d
-	"7bd9d46f-7c3b-4089-88e5-fca17581295e": "p750", // b2i.16d
-	"562af0ba-2540-4b49-943e-0beb6c9afa04": "p750", // b2i.30d
-	"a09e6576-4f74-4a4d-963a-05ec49e27f18": "p750", // b2i.36d
+	"882a98ba-d47f-4a52-bd85-ccbc2b08f8f8": p250, // b2i.1d
+	"6c1b79d7-b344-407e-808d-476187c7dcd6": p750, // b2i.2d
+	"013451f5-4c26-4464-84e6-cc5f1c8b0f8a": p750, // b2i.4d
+	"2787f539-a8b9-40d3-873d-6db51a2edb41": p750, // b2i.8d
+	"7bd9d46f-7c3b-4089-88e5-fca17581295e": p750, // b2i.16d
+	"562af0ba-2540-4b49-943e-0beb6c9afa04": p750, // b2i.30d
+	"a09e6576-4f74-4a4d-963a-05ec49e27f18": p750, // b2i.36d
 
-	"7d1572e1-11c9-4872-8ce8-4b953cdf6fb3": "p50",  // c1.1
-	"5fe737c2-18d8-43c6-bb11-dc9c97ff9515": "p50",  // c1.2
-	"8512c5f9-4426-47f1-a9dc-5c5a5a798b54": "p250", // c1.3
-	"ecb39de6-8b6c-431e-8455-9d857639be92": "p750", // c1.4
-	"442e31fa-654a-4f76-b7c2-4802592f9cc7": "p750", // c1.5
+	"7d1572e1-11c9-4872-8ce8-4b953cdf6fb3": p50,  // c1.1
+	"5fe737c2-18d8-43c6-bb11-dc9c97ff9515": p50,  // c1.2
+	"8512c5f9-4426-47f1-a9dc-5c5a5a798b54": p250, // c1.3
+	"ecb39de6-8b6c-431e-8455-9d857639be92": p750, // c1.4
+	"442e31fa-654a-4f76-b7c2-4802592f9cc7": p750, // c1.5
 
-	"6f65263f-0902-47ca-8761-6e449648c8f0": "p50",  // c1a.1d
-	"a9704593-dc26-45b7-8b1c-a37bf42d253e": "p50",  // c1a.2d
-	"d04236f9-4740-4058-9695-0a80a9b3a9b0": "p250", // c1a.4d
-	"cac16b39-a179-43c5-b5e5-ad22eca1c87c": "p750", // c1a.8d
-	"381b5633-b064-41aa-af78-cd1bd318a0e1": "p750", // c1a.16d
+	"6f65263f-0902-47ca-8761-6e449648c8f0": p50,  // c1a.1d
+	"a9704593-dc26-45b7-8b1c-a37bf42d253e": p50,  // c1a.2d
+	"d04236f9-4740-4058-9695-0a80a9b3a9b0": p250, // c1a.4d
+	"cac16b39-a179-43c5-b5e5-ad22eca1c87c": p750, // c1a.8d
+	"381b5633-b064-41aa-af78-cd1bd318a0e1": p750, // c1a.16d
 
-	"ef66543f-3225-48b0-ab42-4cfda07668b8": "p50",  // c2i.1
-	"0c69d386-ca5e-4720-8812-225bbf4d4879": "p50",  // c2i.2
-	"a03cf8cd-f5e4-4897-b639-41b4a1a46dc6": "p250", // c2i.4
-	"cee66b47-8465-469d-bb61-7a23073c3488": "p750", // c2i.8
-	"5fa8e67c-4259-4353-8e29-dece88c3a394": "p750", // c2i.16
+	"ef66543f-3225-48b0-ab42-4cfda07668b8": p50,  // c2i.1
+	"0c69d386-ca5e-4720-8812-225bbf4d4879": p50,  // c2i.2
+	"a03cf8cd-f5e4-4897-b639-41b4a1a46dc6": p250, // c2i.4
+	"cee66b47-8465-469d-bb61-7a23073c3488": p750, // c2i.8
+	"5fa8e67c-4259-4353-8e29-dece88c3a394": p750, // c2i.16
 
-	"64d695be-04b8-4f14-b020-712ef0e30a6b": "p50",  // g1.1
-	"3b11b27e-6c73-470d-b595-1d85b95a8cdf": "p250", // g1.2
-	"028a4cf9-d9de-4706-a6d2-3ec9a456a736": "p250", // g1.3
-	"21ff0965-d385-4e90-9ae4-e1ac8ca8f569": "p750", // g1.4
-	"d1f51f86-3fa3-46a1-9e9f-b8b1308f039e": "p750", // g1.5
+	"64d695be-04b8-4f14-b020-712ef0e30a6b": p50,  // g1.1
+	"3b11b27e-6c73-470d-b595-1d85b95a8cdf": p250, // g1.2
+	"028a4cf9-d9de-4706-a6d2-3ec9a456a736": p250, // g1.3
+	"21ff0965-d385-4e90-9ae4-e1ac8ca8f569": p750, // g1.4
+	"d1f51f86-3fa3-46a1-9e9f-b8b1308f039e": p750, // g1.5
 
-	"17837ed5-515a-457f-b36b-531fdb861b8a": "p50",  // g1a.1d
-	"c6b4adc7-d101-48d4-a2ea-d77cbaa63768": "p250", // g1a.2d
-	"c995089f-8d81-4085-be7b-dc2f7ad3f05f": "p250", // g1a.4d
-	"cfd6f5f6-b2da-49db-9f1c-4f2ef4c8e831": "p750", // g1a.8d
-	"816c3d62-3526-47c6-90b4-7c47318f7526": "p750", // g1a.16d
-	"84a73cca-db0b-4d56-837f-5e5422520d51": "p750", // g1a.32d
-	"b9f4c5f0-49d7-48a1-ab41-34000f00664b": "p750", // g1a.60d
+	"17837ed5-515a-457f-b36b-531fdb861b8a": p50,  // g1a.1d
+	"c6b4adc7-d101-48d4-a2ea-d77cbaa63768": p250, // g1a.2d
+	"c995089f-8d81-4085-be7b-dc2f7ad3f05f": p250, // g1a.4d
+	"cfd6f5f6-b2da-49db-9f1c-4f2ef4c8e831": p750, // g1a.8d
+	"816c3d62-3526-47c6-90b4-7c47318f7526": p750, // g1a.16d
+	"84a73cca-db0b-4d56-837f-5e5422520d51": p750, // g1a.32d
+	"b9f4c5f0-49d7-48a1-ab41-34000f00664b": p750, // g1a.60d
 
-	"8d811c25-a261-4cbe-aadf-6c2d9667c842": "p50",  // g1r.1d
-	"8a7bd5b4-7ac6-414b-ac62-a6c43229038a": "p250", // g1r.2d
-	"e3abfbba-b9fe-4973-ac92-2856f489d09a": "p250", // g1r.4d
-	"f5bfad0d-22d2-4e47-a807-8413e6d0818f": "p750", // g1r.8d
-	"396a0814-b339-4e9f-8d2f-ccef53937541": "p750", // g1r.16d
-	"a98b686a-4207-4bc2-902a-6f303da7b043": "p750", // g1r.30d
+	"8d811c25-a261-4cbe-aadf-6c2d9667c842": p50,  // g1r.1d
+	"8a7bd5b4-7ac6-414b-ac62-a6c43229038a": p250, // g1r.2d
+	"e3abfbba-b9fe-4973-ac92-2856f489d09a": p250, // g1r.4d
+	"f5bfad0d-22d2-4e47-a807-8413e6d0818f": p750, // g1r.8d
+	"396a0814-b339-4e9f-8d2f-ccef53937541": p750, // g1r.16d
+	"a98b686a-4207-4bc2-902a-6f303da7b043": p750, // g1r.30d
 
-	"474e2367-9c96-4fc0-ac41-eac7f59a1c7b": "p50",  // g2i.1
-	"410cc4c1-0684-47fa-9e72-866f1044a330": "p50",  // g2i.1s
-	"b7aa1635-3726-4924-9d73-18b9683fb67a": "p250", // g2i.2
-	"79021845-f6de-46f0-be07-17835930d030": "p250", // g2i.2s
-	"8d705710-c7a8-4e64-aa96-87add166f42d": "p250", // g2i.4
-	"88883131-9afa-43ad-bc4e-77b79494e89f": "p250", // g2i.4s
-	"9c0a9d2d-79e9-4b99-a72f-e15c0d987e7d": "p750", // g2i.8
-	"f6303887-f07c-4976-9198-0eb0dd964b18": "p750", // g2i.8s
-	"b1ca70ea-4da7-441d-8aef-8337c5f81fb2": "p750", // g2i.16
-	"901a56b3-4c98-4725-986a-2aa081b9c955": "p750", // g2i.16s
+	"474e2367-9c96-4fc0-ac41-eac7f59a1c7b": p50,  // g2i.1
+	"410cc4c1-0684-47fa-9e72-866f1044a330": p50,  // g2i.1s
+	"b7aa1635-3726-4924-9d73-18b9683fb67a": p250, // g2i.2
+	"79021845-f6de-46f0-be07-17835930d030": p250, // g2i.2s
+	"8d705710-c7a8-4e64-aa96-87add166f42d": p250, // g2i.4
+	"88883131-9afa-43ad-bc4e-77b79494e89f": p250, // g2i.4s
+	"9c0a9d2d-79e9-4b99-a72f-e15c0d987e7d": p750, // g2i.8
+	"f6303887-f07c-4976-9198-0eb0dd964b18": p750, // g2i.8s
+	"b1ca70ea-4da7-441d-8aef-8337c5f81fb2": p750, // g2i.16
+	"901a56b3-4c98-4725-986a-2aa081b9c955": p750, // g2i.16s
 
-	"04b9be2d-afee-4f32-874b-8356b96ebb0b": "p50",  // m1.1
-	"39d1344f-91dc-412a-a3b4-72e61b6c6eaa": "p250", // m1.2
-	"baa5374c-cb97-47b9-be8c-e79103b3d097": "p750", // m1.3
-	"ccd8f298-d885-4c8b-bf40-414ee8f39967": "p750", // m1.4
-	"acd9945a-f94a-4e64-a4a3-81f587b596cf": "p750", // m1.5
+	"04b9be2d-afee-4f32-874b-8356b96ebb0b": p50,  // m1.1
+	"39d1344f-91dc-412a-a3b4-72e61b6c6eaa": p250, // m1.2
+	"baa5374c-cb97-47b9-be8c-e79103b3d097": p750, // m1.3
+	"ccd8f298-d885-4c8b-bf40-414ee8f39967": p750, // m1.4
+	"acd9945a-f94a-4e64-a4a3-81f587b596cf": p750, // m1.5
 
-	"osAyv1W3z2TU5D6h": "p10", // m1.amphora
+	"osAyv1W3z2TU5D6h": p10, // m1.amphora
 
-	"a24a1a07-4c66-4030-bbfd-68368e4bb8be": "p50",  // m1a.1d
-	"d61f0a42-a3e0-4723-b78a-d51d3d719ade": "p250", // m1a.2d
-	"27b97158-43d6-44a1-8cf2-d95989f2cc07": "p750", // m1a.4d
-	"9d76cf5e-1354-446f-8ca1-0d704bee89ca": "p750", // m1a.8d
-	"e6897bc6-6a21-451c-b6cb-d80725781446": "p750", // m1a.16d
-	"6fedeb8b-0536-4fbb-80b3-3791d00346b2": "p750", // m1a.32d
-	"e772e068-6400-4664-8813-811e835b169e": "p750", // m1a.60d
-	"ae6ea4bb-f26c-41c1-a974-ff422601c0b6": "p750", // m1a.120d
+	"a24a1a07-4c66-4030-bbfd-68368e4bb8be": p50,  // m1a.1d
+	"d61f0a42-a3e0-4723-b78a-d51d3d719ade": p250, // m1a.2d
+	"27b97158-43d6-44a1-8cf2-d95989f2cc07": p750, // m1a.4d
+	"9d76cf5e-1354-446f-8ca1-0d704bee89ca": p750, // m1a.8d
+	"e6897bc6-6a21-451c-b6cb-d80725781446": p750, // m1a.16d
+	"6fedeb8b-0536-4fbb-80b3-3791d00346b2": p750, // m1a.32d
+	"e772e068-6400-4664-8813-811e835b169e": p750, // m1a.60d
+	"ae6ea4bb-f26c-41c1-a974-ff422601c0b6": p750, // m1a.120d
 
-	"aa603f7b-4214-486c-81ce-369535cef8ed": "p50",  // m2i.1
-	"b4be83e0-475c-4255-a5ef-e6876c413a09": "p250", // m2i.2
-	"79b7b9a7-a062-4aab-9861-ba93c1935a68": "p750", // m2i.4
-	"309471e2-21e8-4384-8ad9-484bf56372b3": "p750", // m2i.8
-	"c4d49baf-fcfa-4ec1-8160-9ec7e57123fc": "p750", // m2i.16
+	"aa603f7b-4214-486c-81ce-369535cef8ed": p50,  // m2i.1
+	"b4be83e0-475c-4255-a5ef-e6876c413a09": p250, // m2i.2
+	"79b7b9a7-a062-4aab-9861-ba93c1935a68": p750, // m2i.4
+	"309471e2-21e8-4384-8ad9-484bf56372b3": p750, // m2i.8
+	"c4d49baf-fcfa-4ec1-8160-9ec7e57123fc": p750, // m2i.16
 
-	"d651f154-7fc9-4bf6-a34a-a32e3dd57c5d": "p50",  // s1.2
-	"8b2c5d9f-e7da-4cd2-a359-e652817845fe": "p50",  // s1.3
-	"709d7f73-41f0-4295-94d5-0f0cf351c93b": "p250", // s1.4
-	"178cf1ad-abcb-46c2-a045-73bc935f100e": "p750", // s1.5
-	"482434d3-3604-4f72-98d8-2af2c654d4e9": "p750", // s1.6
+	"d651f154-7fc9-4bf6-a34a-a32e3dd57c5d": p50,  // s1.2
+	"8b2c5d9f-e7da-4cd2-a359-e652817845fe": p50,  // s1.3
+	"709d7f73-41f0-4295-94d5-0f0cf351c93b": p250, // s1.4
+	"178cf1ad-abcb-46c2-a045-73bc935f100e": p750, // s1.5
+	"482434d3-3604-4f72-98d8-2af2c654d4e9": p750, // s1.6
 
-	"6f04a265-3a9f-4b99-bb66-944ac848af22": "p750", // n1.14d.g1
-	"4b4891d6-860b-4c70-b48e-d261e9751b56": "p750", // n1.28d.g2
+	"6f04a265-3a9f-4b99-bb66-944ac848af22": p750, // n1.14d.g1
+	"4b4891d6-860b-4c70-b48e-d261e9751b56": p750, // n1.28d.g2
 
-	"396671f4-6f19-4531-98d0-127272916cee": "p750", // n2.14d.g1
-	"0c85bbb2-5c85-465c-abf9-71261b8fbcd4": "p750", // n2.28d.g2
-	"a7c5c538-aef1-4f40-8c8d-1366c5b80271": "p750", // n2.56d.g4
+	"396671f4-6f19-4531-98d0-127272916cee": p750, // n2.14d.g1
+	"0c85bbb2-5c85-465c-abf9-71261b8fbcd4": p750, // n2.28d.g2
+	"a7c5c538-aef1-4f40-8c8d-1366c5b80271": p750, // n2.56d.g4
 
-	"25129382-dbe8-43eb-b71b-72253dd69452": "p10", // t1.1
-	"22b37153-8817-4c85-9805-92426b2f903c": "p10", // t2i.1
+	"25129382-dbe8-43eb-b71b-72253dd69452": p10, // t1.1
+	"22b37153-8817-4c85-9805-92426b2f903c": p10, // t2i.1
 }
 
 // proxyProtocolEnableForPort determines whether portNumber should use the TCP proxy protocol (instead of TCP).
@@ -235,7 +239,8 @@ func getPlanID(service *corev1.Service) (planID *string, msgs []string, err erro
 		msgs = append(msgs, fmt.Sprintf(`Flavors are deprecated in favor of service plans. Picking load balancer service plan %s for flavor %s. Use the annotation lb.stackit.cloud/service-plan-id to explicitly choose a service plan.`, planID, flavorID))
 		return &planID, msgs, nil
 	}
-	return &defaultServicePlan, nil, nil
+	// default to p10 if no annotation is provided
+	return new(p10), nil, nil
 }
 
 // lbSpecFromService returns a load balancer specification in the form of a create payload matching the specification of the service, nodes and network.

--- a/pkg/ccm/loadbalancer_spec_test.go
+++ b/pkg/ccm/loadbalancer_spec_test.go
@@ -796,7 +796,7 @@ var _ = Describe("lbSpecFromService", func() {
 			spec, _, err := lbSpecFromService(&corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"lb.stackit.cloud/service-plan-id": "p250",
+						"lb.stackit.cloud/service-plan-id": p250,
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -810,7 +810,7 @@ var _ = Describe("lbSpecFromService", func() {
 				},
 			}, []*corev1.Node{}, lbOpts, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(spec.PlanId).To(HaveValue(BeEquivalentTo("p250")))
+			Expect(spec.PlanId).To(HaveValue(BeEquivalentTo(p250)))
 		})
 		It("should not create an LB with a custom plan when service-plan-id annotation is set to an invalid value", func() {
 			_, _, err := lbSpecFromService(&corev1.Service{
@@ -855,7 +855,7 @@ var _ = Describe("lbSpecFromService", func() {
 			Expect(events[0].Message).To(Equal(`Flavors are deprecated in favor of service plans. Picking load balancer service plan p250 for flavor 72f11e14-2825-471d-a237-b1afa775fdad. Use the annotation lb.stackit.cloud/service-plan-id to explicitly choose a service plan.`))
 			Expect(events[0].Type).To(Equal(corev1.EventTypeWarning))
 			Expect(events[0].Reason).To(Equal(EventReasonSelectedPlanID))
-			Expect(spec.PlanId).To(HaveValue(BeEquivalentTo("p250")))
+			Expect(spec.PlanId).To(HaveValue(BeEquivalentTo(p250)))
 		})
 
 		It("should create an LB with a custom plan when flavor ID annotation is set to a valid value but doesn't match a service plan ID", func() {
@@ -881,7 +881,7 @@ var _ = Describe("lbSpecFromService", func() {
 			Expect(events[0].Message).To(Equal(`Flavors are deprecated in favor of service plans. Picking load balancer service plan p50 for flavor aa603f7b-4214-486c-81ce-369535cef8ed. Use the annotation lb.stackit.cloud/service-plan-id to explicitly choose a service plan.`))
 			Expect(events[0].Type).To(Equal(corev1.EventTypeWarning))
 			Expect(events[0].Reason).To(Equal(EventReasonSelectedPlanID))
-			Expect(spec.PlanId).To(HaveValue(BeEquivalentTo("p50")))
+			Expect(spec.PlanId).To(HaveValue(BeEquivalentTo(p50)))
 		})
 		It("should not create an LB with a custom plan when flavorId annotation is set to an invalid value", func() {
 			_, _, err := lbSpecFromService(&corev1.Service{
@@ -1305,13 +1305,13 @@ var _ = DescribeTable("compareLBwithSpec",
 		wantFulfilled:         false,
 		wantImmutabledChanged: nil,
 		lb: &loadbalancer.LoadBalancer{
-			PlanId: new("p10"),
+			PlanId: new(p10),
 			Options: &loadbalancer.LoadBalancerOptions{
 				EphemeralAddress: new(true),
 			},
 		},
 		spec: &loadbalancer.CreateLoadBalancerPayload{
-			PlanId: new("p250"),
+			PlanId: new(p250),
 			Options: &loadbalancer.LoadBalancerOptions{
 				EphemeralAddress: new(true),
 			},

--- a/pkg/ccm/loadbalancer_test.go
+++ b/pkg/ccm/loadbalancer_test.go
@@ -242,7 +242,7 @@ var _ = Describe("LoadBalancer", func() {
 				Status:          new(lbwait.LOADBALANCERSTATUS_READY),
 				TargetPools:     spec.TargetPools,
 				Version:         new("current-version"),
-				PlanId:          new("p10"),
+				PlanId:          new(p10),
 			}
 
 			mockClient.EXPECT().GetLoadBalancer(gomock.Any(), projectID, gomock.Any()).Return(myLb, nil)


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

In #1045 #1046 #1047 #1048  #1049 the golangci-lint version is bumped. But there is a new download URL, that is why this is failing currently.

This PR also directly address new lint findings with that new version of golang and goconst.

This is done separately (not within the update PR) to avoid merge issues during the cherry-pick.

/cherry-pick release-v1.33
/cherry-pick release-v1.34
/cherry-pick release-v1.35
/cherry-pick release-v1.36

