### PR TITLE
add generic metrics for external API

### DIFF
--- a/cmd/stackit-csi-plugin/main.go
+++ b/cmd/stackit-csi-plugin/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/csi"
@@ -74,7 +75,7 @@ func main() {
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
 	cmd.PersistentFlags().StringVar(&metricsAddress, "metrics-address", "",
-		"The TCP network address where the HTTP server for providing metrics for diagnostics, will listen (example: `:9090`)."+
+		"The TCP network address where the HTTP server for providing metrics for diagnostics, will listen (example: `:8080`)."+
 			"The default is empty string, which means the server is disabled.")
 
 	cmd.PersistentFlags().BoolVar(&provideControllerService, "provide-controller-service", true,
@@ -93,6 +94,8 @@ func main() {
 
 func handle(ctx context.Context) {
 	if metricsAddress != "" {
+		metricsExporter := metrics.NewExporter()
+		prometheus.MustRegister(metricsExporter)
 		go func() {
 			if err := metrics.Run(ctx, metricsAddress); err != nil {
 				klog.Fatalf("Run metrics returned an error: %v", err)

--- a/cmd/stackit-csi-plugin/main.go
+++ b/cmd/stackit-csi-plugin/main.go
@@ -126,10 +126,7 @@ func handle(ctx context.Context) {
 			klog.Fatal(err)
 		}
 
-		iaasHTTPClient, err := metrics.NewInstrumentedHTTPClient(metrics.APINameIaaS)
-		if err != nil {
-			klog.Fatalf("create IaaS metrics HTTP client: %v", err)
-		}
+		iaasHTTPClient := metrics.NewInstrumentedHTTPClient(metrics.APINameIaaS)
 		iaasOpts := []sdkconfig.ConfigurationOption{
 			sdkconfig.WithHTTPClient(iaasHTTPClient),
 		}

--- a/cmd/stackit-csi-plugin/main.go
+++ b/cmd/stackit-csi-plugin/main.go
@@ -110,8 +110,12 @@ func handle() {
 			klog.Fatal(err)
 		}
 
+		iaasHTTPClient, err := metrics.NewInstrumentedHTTPClient(metrics.APINameIaaS)
+		if err != nil {
+			klog.Fatalf("create IaaS metrics HTTP client: %v", err)
+		}
 		iaasOpts := []sdkconfig.ConfigurationOption{
-			sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
+			sdkconfig.WithHTTPClient(iaasHTTPClient),
 		}
 
 		if cfg.Global.APIEndpoints.IaasAPI != "" {

--- a/cmd/stackit-csi-plugin/main.go
+++ b/cmd/stackit-csi-plugin/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -22,7 +25,7 @@ var (
 	endpoint                 string
 	cloudConfig              string
 	cluster                  string
-	httpEndpoint             string
+	metricsAddress           string
 	provideControllerService bool
 	provideNodeService       bool
 	legacyStorageMode        bool
@@ -34,7 +37,10 @@ func main() {
 		Use:   "stackit-csi-plugin",
 		Short: "STACKIT block-storage CSI plugin",
 		Run: func(_ *cobra.Command, _ []string) {
-			handle()
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+			defer cancel()
+
+			handle(ctx)
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			f := cmd.Flags()
@@ -67,8 +73,8 @@ func main() {
 	cmd.Flags().StringVar(&cloudConfig, "cloud-config", "", "CSI driver cloud config. This option can be given multiple times")
 
 	cmd.PersistentFlags().StringVar(&cluster, "cluster", "", "The identifier of the cluster that the plugin is running in.")
-	cmd.PersistentFlags().StringVar(&httpEndpoint, "http-endpoint", "",
-		"The TCP network address where the HTTP server for providing metrics for diagnostics, will listen (example: `:8080`)."+
+	cmd.PersistentFlags().StringVar(&metricsAddress, "metrics-address", "",
+		"The TCP network address where the HTTP server for providing metrics for diagnostics, will listen (example: `:9090`)."+
 			"The default is empty string, which means the server is disabled.")
 
 	cmd.PersistentFlags().BoolVar(&provideControllerService, "provide-controller-service", true,
@@ -85,7 +91,14 @@ func main() {
 	os.Exit(code)
 }
 
-func handle() {
+func handle(ctx context.Context) {
+	if metricsAddress != "" {
+		go func() {
+			if err := metrics.Run(ctx, metricsAddress); err != nil {
+				klog.Fatalf("Run metrics returned an error: %v", err)
+			}
+		}()
+	}
 	// Initialize cloud
 	driverOpts := &blockstorage.DriverOpts{
 		Endpoint:  endpoint,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
@@ -87,7 +88,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.24.0 // indirect

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -117,8 +117,12 @@ func BuildObservability() (*MetricsRemoteWrite, error) {
 
 // NewCloudControllerManager creates a new instance of the stackit struct from a stackitconfig struct
 func NewCloudControllerManager(cfg *stackitconfig.CCMConfig, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
+	lbHTTPClient, err := metrics.NewInstrumentedHTTPClient(metrics.APINameLoadBalancer)
+	if err != nil {
+		return nil, fmt.Errorf("create load balancer metrics HTTP client: %w", err)
+	}
 	lbOpts := []sdkconfig.ConfigurationOption{
-		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
+		sdkconfig.WithHTTPClient(lbHTTPClient),
 	}
 
 	if cfg.Global.APIEndpoints.LoadBalancerAPI != "" {
@@ -138,8 +142,12 @@ func NewCloudControllerManager(cfg *stackitconfig.CCMConfig, obs *MetricsRemoteW
 		return nil, fmt.Errorf("failed to create lb client: %v", err)
 	}
 
+	iaasHTTPClient, err := metrics.NewInstrumentedHTTPClient(metrics.APINameIaaS)
+	if err != nil {
+		return nil, fmt.Errorf("create IaaS metrics HTTP client: %w", err)
+	}
 	iaasOpts := []sdkconfig.ConfigurationOption{
-		sdkconfig.WithHTTPClient(metrics.NewInstrumentedHTTPClient()),
+		sdkconfig.WithHTTPClient(iaasHTTPClient),
 	}
 
 	if cfg.Global.APIEndpoints.IaasAPI != "" {

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -117,10 +117,7 @@ func BuildObservability() (*MetricsRemoteWrite, error) {
 
 // NewCloudControllerManager creates a new instance of the stackit struct from a stackitconfig struct
 func NewCloudControllerManager(cfg *stackitconfig.CCMConfig, obs *MetricsRemoteWrite) (*CloudControllerManager, error) {
-	lbHTTPClient, err := metrics.NewInstrumentedHTTPClient(metrics.APINameLoadBalancer)
-	if err != nil {
-		return nil, fmt.Errorf("create load balancer metrics HTTP client: %w", err)
-	}
+	lbHTTPClient := metrics.NewInstrumentedHTTPClient(metrics.APINameLoadBalancer)
 	lbOpts := []sdkconfig.ConfigurationOption{
 		sdkconfig.WithHTTPClient(lbHTTPClient),
 	}
@@ -142,10 +139,7 @@ func NewCloudControllerManager(cfg *stackitconfig.CCMConfig, obs *MetricsRemoteW
 		return nil, fmt.Errorf("failed to create lb client: %v", err)
 	}
 
-	iaasHTTPClient, err := metrics.NewInstrumentedHTTPClient(metrics.APINameIaaS)
-	if err != nil {
-		return nil, fmt.Errorf("create IaaS metrics HTTP client: %w", err)
-	}
+	iaasHTTPClient := metrics.NewInstrumentedHTTPClient(metrics.APINameIaaS)
 	iaasOpts := []sdkconfig.ConfigurationOption{
 		sdkconfig.WithHTTPClient(iaasHTTPClient),
 	}

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,8 +34,11 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 		With(prometheus.Labels{operationLabel: operation}).
 		Inc()
 
-	if response != nil && response.StatusCode >= http.StatusInternalServerError {
-		LoadBalancerErrorCount.Inc()
+	if response != nil && response.StatusCode >= 400 {
+		HTTPErrorCount.With(prometheus.Labels{
+			"method":     request.Method,
+			"code":       strconv.Itoa(response.StatusCode),
+		}).Inc()
 	}
 
 	return response, err

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -31,12 +31,17 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 	response, err := rt.base.RoundTrip(request)
 	duration := time.Since(startTime)
 
+	statusCode := ""
+	if response != nil {
+		statusCode = strconv.Itoa(response.StatusCode)
+	}
+
 	HTTPRequestDurationHistogram.
 		With(prometheus.Labels{
 			apiLabel:       rt.api,
 			methodLabel:    request.Method,
 			operationLabel: operation,
-			codeLabel:      strconv.Itoa(response.StatusCode),
+			codeLabel:      statusCode,
 		}).
 		Observe(float64(duration.Seconds()))
 	HTTPRequestCount.
@@ -44,7 +49,7 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 			apiLabel:       rt.api,
 			methodLabel:    request.Method,
 			operationLabel: operation,
-			codeLabel:      strconv.Itoa(response.StatusCode),
+			codeLabel:      statusCode,
 		}).
 		Inc()
 
@@ -53,7 +58,7 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 			apiLabel:       rt.api,
 			methodLabel:    request.Method,
 			operationLabel: operation,
-			codeLabel:      strconv.Itoa(response.StatusCode),
+			codeLabel:      statusCode,
 		}).Inc()
 	}
 

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -36,8 +36,8 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 
 	if response != nil && response.StatusCode >= 400 {
 		HTTPErrorCount.With(prometheus.Labels{
-			"method":     request.Method,
-			"code":       strconv.Itoa(response.StatusCode),
+			"method": request.Method,
+			"code":   strconv.Itoa(response.StatusCode),
 		}).Inc()
 	}
 

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -12,10 +11,6 @@ import (
 )
 
 func NewInstrumentedHTTPClient(api string) (*http.Client, error) {
-	if api == "" {
-		return nil, errors.New("api name is required")
-	}
-
 	return &http.Client{
 		Transport: &InstrumentedRoundTripper{
 			api:  api,

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -27,10 +27,10 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 	response, err := rt.base.RoundTrip(request)
 	duration := time.Since(startTime)
 
-	LoadBalancerResponseTimeHistogram.
+	HTTPRequestDurationHistogram.
 		With(prometheus.Labels{operationLabel: operation}).
 		Observe(float64(duration.Seconds()))
-	LoadBalancerRequestCount.
+	HTTPRequestCount.
 		With(prometheus.Labels{operationLabel: operation}).
 		Inc()
 

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -10,13 +10,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewInstrumentedHTTPClient(api string) (*http.Client, error) {
+func NewInstrumentedHTTPClient(api string) *http.Client {
 	return &http.Client{
 		Transport: &InstrumentedRoundTripper{
 			api:  api,
 			base: http.DefaultTransport,
 		},
-	}, nil
+	}
 }
 
 type InstrumentedRoundTripper struct {

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -31,35 +31,26 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 	response, err := rt.base.RoundTrip(request)
 	duration := time.Since(startTime)
 
-	statusCode := ""
+	statusCode := "network_error"
 	if response != nil {
 		statusCode = strconv.Itoa(response.StatusCode)
 	}
 
-	HTTPRequestDurationHistogram.
-		With(prometheus.Labels{
-			apiLabel:       rt.api,
-			methodLabel:    request.Method,
-			operationLabel: operation,
-			codeLabel:      statusCode,
-		}).
-		Observe(float64(duration.Seconds()))
-	HTTPRequestCount.
-		With(prometheus.Labels{
-			apiLabel:       rt.api,
-			methodLabel:    request.Method,
-			operationLabel: operation,
-			codeLabel:      statusCode,
-		}).
-		Inc()
+	labels := prometheus.Labels{
+		apiLabel:       rt.api,
+		methodLabel:    request.Method,
+		operationLabel: operation,
+		codeLabel:      statusCode,
+	}
 
-	if response != nil && response.StatusCode >= 400 {
-		HTTPErrorCount.With(prometheus.Labels{
-			apiLabel:       rt.api,
-			methodLabel:    request.Method,
-			operationLabel: operation,
-			codeLabel:      statusCode,
-		}).Inc()
+	HTTPRequestDurationHistogram.With(labels).Observe(duration.Seconds())
+	HTTPRequestCount.With(labels).Inc()
+
+	isHTTPError := response != nil && response.StatusCode >= 400
+	isNetworkError := err != nil
+
+	if isHTTPError || isNetworkError {
+		HTTPErrorCount.With(labels).Inc()
 	}
 
 	return response, err

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -51,9 +51,9 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 
 	if response != nil && response.StatusCode >= 400 {
 		HTTPErrorCount.With(prometheus.Labels{
-			apiLabel: rt.api,
-			"method": request.Method,
-			"code":   strconv.Itoa(response.StatusCode),
+			apiLabel:    rt.api,
+			methodLabel: request.Method,
+			codeLabel:   strconv.Itoa(response.StatusCode),
 		}).Inc()
 	}
 

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -10,13 +11,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewInstrumentedHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &InstrumentedRoundTripper{http.DefaultTransport},
+func NewInstrumentedHTTPClient(api string) (*http.Client, error) {
+	if api == "" {
+		return nil, errors.New("api name is required")
 	}
+
+	return &http.Client{
+		Transport: &InstrumentedRoundTripper{
+			api:  api,
+			base: http.DefaultTransport,
+		},
+	}, nil
 }
 
 type InstrumentedRoundTripper struct {
+	api  string
 	base http.RoundTripper
 }
 
@@ -28,14 +37,21 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 	duration := time.Since(startTime)
 
 	HTTPRequestDurationHistogram.
-		With(prometheus.Labels{operationLabel: operation}).
+		With(prometheus.Labels{
+			apiLabel:       rt.api,
+			operationLabel: operation,
+		}).
 		Observe(float64(duration.Seconds()))
 	HTTPRequestCount.
-		With(prometheus.Labels{operationLabel: operation}).
+		With(prometheus.Labels{
+			apiLabel:       rt.api,
+			operationLabel: operation,
+		}).
 		Inc()
 
 	if response != nil && response.StatusCode >= 400 {
 		HTTPErrorCount.With(prometheus.Labels{
+			apiLabel: rt.api,
 			"method": request.Method,
 			"code":   strconv.Itoa(response.StatusCode),
 		}).Inc()

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -34,21 +34,26 @@ func (rt *InstrumentedRoundTripper) RoundTrip(request *http.Request) (*http.Resp
 	HTTPRequestDurationHistogram.
 		With(prometheus.Labels{
 			apiLabel:       rt.api,
+			methodLabel:    request.Method,
 			operationLabel: operation,
+			codeLabel:      strconv.Itoa(response.StatusCode),
 		}).
 		Observe(float64(duration.Seconds()))
 	HTTPRequestCount.
 		With(prometheus.Labels{
 			apiLabel:       rt.api,
+			methodLabel:    request.Method,
 			operationLabel: operation,
+			codeLabel:      strconv.Itoa(response.StatusCode),
 		}).
 		Inc()
 
 	if response != nil && response.StatusCode >= 400 {
 		HTTPErrorCount.With(prometheus.Labels{
-			apiLabel:    rt.api,
-			methodLabel: request.Method,
-			codeLabel:   strconv.Itoa(response.StatusCode),
+			apiLabel:       rt.api,
+			methodLabel:    request.Method,
+			operationLabel: operation,
+			codeLabel:      strconv.Itoa(response.StatusCode),
 		}).Inc()
 	}
 

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -28,12 +28,6 @@ var _ = Describe("Metrics", func() {
 	)
 
 	Describe("InstrumentedRoundTripper", func() {
-		It("requires an API name", func() {
-			client, err := NewInstrumentedHTTPClient("")
-			Expect(err).To(MatchError("api name is required"))
-			Expect(client).To(BeNil())
-		})
-
 		It("increments HTTPRequestCount for responses", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -80,52 +74,62 @@ var _ = Describe("Metrics", func() {
 			Expect(after - before).To(Equal(uint64(1)))
 		})
 
-		It("increments HTTPErrorCount for 400 responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		It("increments HTTPErrorCount for error responses (400, 404, 500)", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				if r.URL.Path == "/404" {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
 				w.WriteHeader(http.StatusBadRequest)
 			}))
 			defer server.Close()
 
-			labels := prometheus.Labels{
+			labels400 := prometheus.Labels{
 				apiLabel:    "test",
 				methodLabel: http.MethodGet,
 				codeLabel:   "400",
 			}
-			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
-
-			client, err := NewInstrumentedHTTPClient("test")
-			Expect(err).NotTo(HaveOccurred())
-
-			response, err := client.Get(server.URL)
-			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
-
-			after := testutil.ToFloat64(HTTPErrorCount.With(labels))
-			Expect(after - before).To(Equal(float64(1)))
-		})
-
-		It("increments HTTPErrorCount for 500 responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusInternalServerError)
-			}))
-			defer server.Close()
-
-			labels := prometheus.Labels{
+			labels404 := prometheus.Labels{
+				apiLabel:    "test",
+				methodLabel: http.MethodGet,
+				codeLabel:   "404",
+			}
+			labels500 := prometheus.Labels{
 				apiLabel:    "test",
 				methodLabel: http.MethodPost,
 				codeLabel:   "500",
 			}
-			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
+			before400 := testutil.ToFloat64(HTTPErrorCount.With(labels400))
+			before404 := testutil.ToFloat64(HTTPErrorCount.With(labels404))
+			before500 := testutil.ToFloat64(HTTPErrorCount.With(labels500))
 
 			client, err := NewInstrumentedHTTPClient("test")
 			Expect(err).NotTo(HaveOccurred())
 
-			response, err := client.Post(server.URL, "application/json", nil)
+			response1, err := client.Get(server.URL)
 			Expect(err).NotTo(HaveOccurred())
-			defer response.Body.Close()
+			defer response1.Body.Close()
 
-			after := testutil.ToFloat64(HTTPErrorCount.With(labels))
-			Expect(after - before).To(Equal(float64(1)))
+			response2, err := client.Get(server.URL + "/404")
+			Expect(err).NotTo(HaveOccurred())
+			defer response2.Body.Close()
+
+			response3, err := client.Post(server.URL, "application/json", nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer response3.Body.Close()
+
+			after400 := testutil.ToFloat64(HTTPErrorCount.With(labels400))
+			after404 := testutil.ToFloat64(HTTPErrorCount.With(labels404))
+			after500 := testutil.ToFloat64(HTTPErrorCount.With(labels500))
+
+			Expect(after400 - before400).To(Equal(float64(1)))
+			Expect(after404 - before404).To(Equal(float64(1)))
+			Expect(after500 - before500).To(Equal(float64(1)))
+			Expect((after400 - before400) + (after404 - before404) + (after500 - before500)).To(Equal(float64(3)))
 		})
 
 		It("does not increment HTTPErrorCount for successful responses", func() {

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -40,8 +40,7 @@ var _ = Describe("Metrics", func() {
 			}
 			before := testutil.ToFloat64(HTTPRequestCount.With(labels))
 
-			client, err := NewInstrumentedHTTPClient("test")
-			Expect(err).NotTo(HaveOccurred())
+			client := NewInstrumentedHTTPClient("test")
 
 			response, err := client.Get(server.URL + "/request-count-test")
 			Expect(err).NotTo(HaveOccurred())
@@ -63,8 +62,7 @@ var _ = Describe("Metrics", func() {
 			}
 			before := histogramSampleCount(HTTPRequestDurationHistogram.With(labels))
 
-			client, err := NewInstrumentedHTTPClient("test")
-			Expect(err).NotTo(HaveOccurred())
+			client := NewInstrumentedHTTPClient("test")
 
 			response, err := client.Get(server.URL + "/request-duration-test")
 			Expect(err).NotTo(HaveOccurred())
@@ -107,8 +105,7 @@ var _ = Describe("Metrics", func() {
 			before404 := testutil.ToFloat64(HTTPErrorCount.With(labels404))
 			before500 := testutil.ToFloat64(HTTPErrorCount.With(labels500))
 
-			client, err := NewInstrumentedHTTPClient("test")
-			Expect(err).NotTo(HaveOccurred())
+			client := NewInstrumentedHTTPClient("test")
 
 			response1, err := client.Get(server.URL)
 			Expect(err).NotTo(HaveOccurred())
@@ -145,8 +142,7 @@ var _ = Describe("Metrics", func() {
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 
-			client, err := NewInstrumentedHTTPClient("test")
-			Expect(err).NotTo(HaveOccurred())
+			client := NewInstrumentedHTTPClient("test")
 
 			response, err := client.Get(server.URL)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var _ = Describe("Metrics", func() {
@@ -27,6 +28,44 @@ var _ = Describe("Metrics", func() {
 	)
 
 	Describe("InstrumentedRoundTripper", func() {
+		It("increments HTTPRequestCount for responses", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			labels := prometheus.Labels{
+				operationLabel: "get_request-count-test",
+			}
+			before := testutil.ToFloat64(HTTPRequestCount.With(labels))
+
+			response, err := NewInstrumentedHTTPClient().Get(server.URL + "/request-count-test")
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			after := testutil.ToFloat64(HTTPRequestCount.With(labels))
+			Expect(after - before).To(Equal(float64(1)))
+		})
+
+		It("records HTTPRequestDurationHistogram observations for responses", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			labels := prometheus.Labels{
+				operationLabel: "get_request-duration-test",
+			}
+			before := histogramSampleCount(HTTPRequestDurationHistogram.With(labels))
+
+			response, err := NewInstrumentedHTTPClient().Get(server.URL + "/request-duration-test")
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			after := histogramSampleCount(HTTPRequestDurationHistogram.With(labels))
+			Expect(after - before).To(Equal(uint64(1)))
+		})
+
 		It("increments HTTPErrorCount for 400 responses", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
@@ -88,3 +127,13 @@ var _ = Describe("Metrics", func() {
 		})
 	})
 })
+
+func histogramSampleCount(observer prometheus.Observer) uint64 {
+	metric, ok := observer.(prometheus.Metric)
+	Expect(ok).To(BeTrue())
+
+	dtoMetric := &dto.Metric{}
+	Expect(metric.Write(dtoMetric)).To(Succeed())
+
+	return dtoMetric.GetHistogram().GetSampleCount()
+}

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("increments HTTPRequestCount for responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer server.Close()
@@ -58,7 +58,7 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("records HTTPRequestDurationHistogram observations for responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer server.Close()
@@ -81,15 +81,15 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("increments HTTPErrorCount for 400 responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 			}))
 			defer server.Close()
 
 			labels := prometheus.Labels{
-				apiLabel: "test",
-				"method": http.MethodGet,
-				"code":   "400",
+				apiLabel:    "test",
+				methodLabel: http.MethodGet,
+				codeLabel:   "400",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 
@@ -105,15 +105,15 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("increments HTTPErrorCount for 500 responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			}))
 			defer server.Close()
 
 			labels := prometheus.Labels{
-				apiLabel: "test",
-				"method": http.MethodPost,
-				"code":   "500",
+				apiLabel:    "test",
+				methodLabel: http.MethodPost,
+				codeLabel:   "500",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 
@@ -129,15 +129,15 @@ var _ = Describe("Metrics", func() {
 		})
 
 		It("does not increment HTTPErrorCount for successful responses", func() {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer server.Close()
 
 			labels := prometheus.Labels{
-				apiLabel: "test",
-				"method": http.MethodGet,
-				"code":   "200",
+				apiLabel:    "test",
+				methodLabel: http.MethodGet,
+				codeLabel:   "200",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -2,10 +2,13 @@ package metrics
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 var _ = Describe("Metrics", func() {
@@ -22,4 +25,66 @@ var _ = Describe("Metrics", func() {
 		Entry("get load-balancers", "GET", "/v2/projects/6-a-4-8-c/regions/eu01/load-balancers", "get_load-balancers"),
 		Entry("get load-balancers instance", "GET", "/v2/projects/6-a-4-8-c/regions/eu01/load-balancers/id", "get_load-balancers_instance"),
 	)
+
+	Describe("InstrumentedRoundTripper", func() {
+		It("increments HTTPErrorCount for 400 responses", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			}))
+			defer server.Close()
+
+			labels := prometheus.Labels{
+				"method": http.MethodGet,
+				"code":   "400",
+			}
+			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
+
+			response, err := NewInstrumentedHTTPClient().Get(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			after := testutil.ToFloat64(HTTPErrorCount.With(labels))
+			Expect(after - before).To(Equal(float64(1)))
+		})
+
+		It("increments HTTPErrorCount for 500 responses", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+
+			labels := prometheus.Labels{
+				"method": http.MethodPost,
+				"code":   "500",
+			}
+			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
+
+			response, err := NewInstrumentedHTTPClient().Post(server.URL, "application/json", nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			after := testutil.ToFloat64(HTTPErrorCount.With(labels))
+			Expect(after - before).To(Equal(float64(1)))
+		})
+
+		It("does not increment HTTPErrorCount for successful responses", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			labels := prometheus.Labels{
+				"method": http.MethodGet,
+				"code":   "200",
+			}
+			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
+
+			response, err := NewInstrumentedHTTPClient().Get(server.URL)
+			Expect(err).NotTo(HaveOccurred())
+			defer response.Body.Close()
+
+			after := testutil.ToFloat64(HTTPErrorCount.With(labels))
+			Expect(after - before).To(Equal(float64(0)))
+		})
+	})
 })

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -36,7 +36,9 @@ var _ = Describe("Metrics", func() {
 
 			labels := prometheus.Labels{
 				apiLabel:       "test",
+				methodLabel:    "GET",
 				operationLabel: "get_request-count-test",
+				codeLabel:      "200",
 			}
 			before := testutil.ToFloat64(HTTPRequestCount.With(labels))
 
@@ -58,7 +60,9 @@ var _ = Describe("Metrics", func() {
 
 			labels := prometheus.Labels{
 				apiLabel:       "test",
+				methodLabel:    "GET",
 				operationLabel: "get_request-duration-test",
+				codeLabel:      "200",
 			}
 			before := histogramSampleCount(HTTPRequestDurationHistogram.With(labels))
 
@@ -87,19 +91,22 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels400 := prometheus.Labels{
-				apiLabel:    "test",
-				methodLabel: http.MethodGet,
-				codeLabel:   "400",
+				apiLabel:       "test",
+				methodLabel:    http.MethodGet,
+				operationLabel: "get_",
+				codeLabel:      "400",
 			}
 			labels404 := prometheus.Labels{
-				apiLabel:    "test",
-				methodLabel: http.MethodGet,
-				codeLabel:   "404",
+				apiLabel:       "test",
+				methodLabel:    http.MethodGet,
+				operationLabel: "get_404",
+				codeLabel:      "404",
 			}
 			labels500 := prometheus.Labels{
-				apiLabel:    "test",
-				methodLabel: http.MethodPost,
-				codeLabel:   "500",
+				apiLabel:       "test",
+				methodLabel:    http.MethodPost,
+				operationLabel: "post_",
+				codeLabel:      "500",
 			}
 			before400 := testutil.ToFloat64(HTTPErrorCount.With(labels400))
 			before404 := testutil.ToFloat64(HTTPErrorCount.With(labels404))
@@ -136,9 +143,10 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels := prometheus.Labels{
-				apiLabel:    "test",
-				methodLabel: http.MethodGet,
-				codeLabel:   "200",
+				apiLabel:       "test",
+				methodLabel:    http.MethodGet,
+				operationLabel: "get_",
+				codeLabel:      "200",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 

--- a/pkg/metrics/http_test.go
+++ b/pkg/metrics/http_test.go
@@ -28,6 +28,12 @@ var _ = Describe("Metrics", func() {
 	)
 
 	Describe("InstrumentedRoundTripper", func() {
+		It("requires an API name", func() {
+			client, err := NewInstrumentedHTTPClient("")
+			Expect(err).To(MatchError("api name is required"))
+			Expect(client).To(BeNil())
+		})
+
 		It("increments HTTPRequestCount for responses", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -35,11 +41,15 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels := prometheus.Labels{
+				apiLabel:       "test",
 				operationLabel: "get_request-count-test",
 			}
 			before := testutil.ToFloat64(HTTPRequestCount.With(labels))
 
-			response, err := NewInstrumentedHTTPClient().Get(server.URL + "/request-count-test")
+			client, err := NewInstrumentedHTTPClient("test")
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err := client.Get(server.URL + "/request-count-test")
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -54,11 +64,15 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels := prometheus.Labels{
+				apiLabel:       "test",
 				operationLabel: "get_request-duration-test",
 			}
 			before := histogramSampleCount(HTTPRequestDurationHistogram.With(labels))
 
-			response, err := NewInstrumentedHTTPClient().Get(server.URL + "/request-duration-test")
+			client, err := NewInstrumentedHTTPClient("test")
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err := client.Get(server.URL + "/request-duration-test")
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -73,12 +87,16 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels := prometheus.Labels{
+				apiLabel: "test",
 				"method": http.MethodGet,
 				"code":   "400",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 
-			response, err := NewInstrumentedHTTPClient().Get(server.URL)
+			client, err := NewInstrumentedHTTPClient("test")
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err := client.Get(server.URL)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -93,12 +111,16 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels := prometheus.Labels{
+				apiLabel: "test",
 				"method": http.MethodPost,
 				"code":   "500",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 
-			response, err := NewInstrumentedHTTPClient().Post(server.URL, "application/json", nil)
+			client, err := NewInstrumentedHTTPClient("test")
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err := client.Post(server.URL, "application/json", nil)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 
@@ -113,12 +135,16 @@ var _ = Describe("Metrics", func() {
 			defer server.Close()
 
 			labels := prometheus.Labels{
+				apiLabel: "test",
 				"method": http.MethodGet,
 				"code":   "200",
 			}
 			before := testutil.ToFloat64(HTTPErrorCount.With(labels))
 
-			response, err := NewInstrumentedHTTPClient().Get(server.URL)
+			client, err := NewInstrumentedHTTPClient("test")
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err := client.Get(server.URL)
 			Expect(err).NotTo(HaveOccurred())
 			defer response.Body.Close()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -8,7 +8,7 @@ const (
 	cloudProviderMetricPrefix = "cloud_provider_stackit"
 	apiLabel                  = "api"
 	methodLabel               = "method"
-	codeLabel                 = "code"
+	codeLabel                 = "status_code"
 	operationLabel            = "op"
 
 	APINameLoadBalancer = "loadbalancer"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,13 +19,12 @@ var (
 		ConstLabels: nil,
 	}, []string{operationLabel})
 
-	LoadBalancerErrorCount = prometheus.NewCounter(prometheus.CounterOpts{
+	HTTPErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   cloudProviderMetricPrefix,
-		Subsystem:   loadBalancerSubSystem,
-		Name:        "errors_total",
-		Help:        "the number of server errors reported when calling the load balancer API",
+		Name:        "http_errors_total",
+		Help:        "Number of HTTP errors returned by external APIs",
 		ConstLabels: nil,
-	})
+	}, []string{"method", "code"})
 
 	LoadBalancerResponseTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   cloudProviderMetricPrefix,
@@ -56,12 +55,12 @@ func (e *Exporter) Collect(metrics chan<- prometheus.Metric) {
 
 func (e *Exporter) describeCloudProvider(descs chan<- *prometheus.Desc) {
 	LoadBalancerRequestCount.Describe(descs)
-	LoadBalancerErrorCount.Describe(descs)
+	HTTPErrorCount.Describe(descs)
 	LoadBalancerResponseTimeHistogram.Describe(descs)
 }
 
 func (e *Exporter) collectCloudProvider(metrics chan<- prometheus.Metric) {
 	LoadBalancerRequestCount.Collect(metrics)
-	LoadBalancerErrorCount.Collect(metrics)
+	HTTPErrorCount.Collect(metrics)
 	LoadBalancerResponseTimeHistogram.Collect(metrics)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,16 +6,14 @@ import (
 
 const (
 	cloudProviderMetricPrefix = "cloud_provider_stackit"
-	loadBalancerSubSystem     = "lb"
 	operationLabel            = "op"
 )
 
 var (
-	LoadBalancerRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	HTTPRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   cloudProviderMetricPrefix,
-		Subsystem:   loadBalancerSubSystem,
-		Name:        "requests_total",
-		Help:        "the number of requests to the load balancer API",
+		Name:        "http_requests_total",
+		Help:        "The number of requests to external APIs",
 		ConstLabels: nil,
 	}, []string{operationLabel})
 
@@ -26,11 +24,10 @@ var (
 		ConstLabels: nil,
 	}, []string{"method", "code"})
 
-	LoadBalancerResponseTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	HTTPRequestDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   cloudProviderMetricPrefix,
-		Subsystem:   loadBalancerSubSystem,
-		Name:        "request_duration_seconds",
-		Help:        "the response times of the load balancer API",
+		Name:        "http_request_duration_seconds",
+		Help:        "The response times of external API requests",
 		ConstLabels: nil,
 		Buckets:     nil,
 	}, []string{operationLabel})
@@ -54,13 +51,13 @@ func (e *Exporter) Collect(metrics chan<- prometheus.Metric) {
 }
 
 func (e *Exporter) describeCloudProvider(descs chan<- *prometheus.Desc) {
-	LoadBalancerRequestCount.Describe(descs)
+	HTTPRequestCount.Describe(descs)
 	HTTPErrorCount.Describe(descs)
-	LoadBalancerResponseTimeHistogram.Describe(descs)
+	HTTPRequestDurationHistogram.Describe(descs)
 }
 
 func (e *Exporter) collectCloudProvider(metrics chan<- prometheus.Metric) {
-	LoadBalancerRequestCount.Collect(metrics)
+	HTTPRequestCount.Collect(metrics)
 	HTTPErrorCount.Collect(metrics)
-	LoadBalancerResponseTimeHistogram.Collect(metrics)
+	HTTPRequestDurationHistogram.Collect(metrics)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,14 +21,14 @@ var (
 		Name:        "http_requests_total",
 		Help:        "The number of requests to external APIs",
 		ConstLabels: nil,
-	}, []string{apiLabel, operationLabel})
+	}, []string{apiLabel, methodLabel, operationLabel, codeLabel})
 
 	HTTPErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   cloudProviderMetricPrefix,
 		Name:        "http_errors_total",
 		Help:        "Number of HTTP errors returned by external APIs",
 		ConstLabels: nil,
-	}, []string{apiLabel, methodLabel, codeLabel})
+	}, []string{apiLabel, methodLabel, operationLabel, codeLabel})
 
 	HTTPRequestDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   cloudProviderMetricPrefix,
@@ -36,7 +36,7 @@ var (
 		Help:        "The response times of external API requests",
 		ConstLabels: nil,
 		Buckets:     nil,
-	}, []string{apiLabel, operationLabel})
+	}, []string{apiLabel, methodLabel, operationLabel, codeLabel})
 )
 
 type Exporter struct {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,6 +7,8 @@ import (
 const (
 	cloudProviderMetricPrefix = "cloud_provider_stackit"
 	apiLabel                  = "api"
+	methodLabel               = "method"
+	codeLabel                 = "code"
 	operationLabel            = "op"
 
 	APINameLoadBalancer = "loadbalancer"
@@ -26,7 +28,7 @@ var (
 		Name:        "http_errors_total",
 		Help:        "Number of HTTP errors returned by external APIs",
 		ConstLabels: nil,
-	}, []string{apiLabel, "method", "code"})
+	}, []string{apiLabel, methodLabel, codeLabel})
 
 	HTTPRequestDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   cloudProviderMetricPrefix,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,7 +6,11 @@ import (
 
 const (
 	cloudProviderMetricPrefix = "cloud_provider_stackit"
+	apiLabel                  = "api"
 	operationLabel            = "op"
+
+	APINameLoadBalancer = "loadbalancer"
+	APINameIaaS         = "iaas"
 )
 
 var (
@@ -15,14 +19,14 @@ var (
 		Name:        "http_requests_total",
 		Help:        "The number of requests to external APIs",
 		ConstLabels: nil,
-	}, []string{operationLabel})
+	}, []string{apiLabel, operationLabel})
 
 	HTTPErrorCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   cloudProviderMetricPrefix,
 		Name:        "http_errors_total",
 		Help:        "Number of HTTP errors returned by external APIs",
 		ConstLabels: nil,
-	}, []string{"method", "code"})
+	}, []string{apiLabel, "method", "code"})
 
 	HTTPRequestDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   cloudProviderMetricPrefix,
@@ -30,7 +34,7 @@ var (
 		Help:        "The response times of external API requests",
 		ConstLabels: nil,
 		Buckets:     nil,
-	}, []string{operationLabel})
+	}, []string{apiLabel, operationLabel})
 )
 
 type Exporter struct {


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:

This PR enables using generic metrics for all the external API (IaaS & Loadbalancer) and also track error code more than 400 unlike 500 previously.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
