### PR TITLE
skip setting readonly LB fields in the update call

### DIFF
--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -148,14 +148,12 @@ func (l *LoadBalancer) EnsureLoadBalancer( //nolint:gocyclo // not really comple
 		spec.Version = lb.Version
 		spec.Name = &name
 		updatePayload := &loadbalancer.UpdateLoadBalancerPayload{
-			Errors:          spec.Errors,
 			ExternalAddress: spec.ExternalAddress,
 			Listeners:       spec.Listeners,
 			Name:            spec.Name,
 			Networks:        spec.Networks,
 			Options:         spec.Options,
 			PlanId:          spec.PlanId,
-			PrivateAddress:  spec.PrivateAddress,
 			Region:          spec.Region,
 			Labels:          spec.Labels,
 			TargetPools:     spec.TargetPools,

--- a/pkg/ccm/loadbalancer.go
+++ b/pkg/ccm/loadbalancer.go
@@ -158,7 +158,6 @@ func (l *LoadBalancer) EnsureLoadBalancer( //nolint:gocyclo // not really comple
 			PrivateAddress:  spec.PrivateAddress,
 			Region:          spec.Region,
 			Labels:          spec.Labels,
-			Status:          new(loadbalancer.UpdateLoadBalancerPayloadStatus(spec.GetStatus())),
 			TargetPools:     spec.TargetPools,
 			Version:         spec.Version,
 		}


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind regression

**What this PR does / why we need it**:
After the LB SDK update, creating LoadBalancer did work, but updating them resulted in an issue due to the status being an empty string instead of a nil pointer. We never set the status anyways, so we should remove that. The status should be a "read only" value anyway.
Errors and PrivateAddress are also readonly fields that got removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
