### PR TITLE
Fix golangci-lint install script

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -39,7 +39,7 @@ $(GOIMPORTS_REVISER): $(call tool_version_file,$(GOIMPORTS_REVISER),$(GOIMPORTS_
 
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERSION))
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(TOOLS_BIN_DIR) $(GOLANGCI_LINT_VERSION)
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 MOCKGEN := $(TOOLS_BIN_DIR)/mockgen
 $(MOCKGEN): $(call tool_version_file,$(MOCKGEN),$(MOCKGEN_VERSION))

--- a/pkg/csi/util/mount/mount_helper.go
+++ b/pkg/csi/util/mount/mount_helper.go
@@ -58,7 +58,6 @@ func countFreePCIeSlotsAt(devicesPath string) (int64, error) {
 	return freePCIeSlots, nil
 }
 
-//nolint:unparam // driverName is always the same when running the linter on macOS but different on linux
 func countLocalCSIVolumesAt(csiPluginDir, driverName string) (int64, error) {
 	driverPluginDir := filepath.Join(csiPluginDir, driverName)
 

--- a/pkg/csi/util/mount/mount_helper.go
+++ b/pkg/csi/util/mount/mount_helper.go
@@ -58,6 +58,7 @@ func countFreePCIeSlotsAt(devicesPath string) (int64, error) {
 	return freePCIeSlots, nil
 }
 
+//nolint:unparam // driverName is always the same when running the linter on macOS but different on linux
 func countLocalCSIVolumesAt(csiPluginDir, driverName string) (int64, error) {
 	driverPluginDir := filepath.Join(csiPluginDir, driverName)
 

--- a/pkg/csi/util/mount/mount_helper_test.go
+++ b/pkg/csi/util/mount/mount_helper_test.go
@@ -105,13 +105,17 @@ var _ = Describe("Mount helpers", func() {
 			Expect(count).To(Equal(int64(1)))
 		})
 
-		It("ignores block metadata for other CSI drivers", func() {
+		It("filters block metadata by CSI driver", func() {
 			csiPluginDir := GinkgoT().TempDir()
 			mustWriteVolumeMetadata(csiPluginDir, "block-volume-a", "other.csi.example")
 
 			count, err := countLocalCSIVolumesAt(csiPluginDir, "block-storage.csi.stackit.cloud")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(count).To(BeZero())
+
+			count, err = countLocalCSIVolumesAt(csiPluginDir, "other.csi.example")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(int64(1)))
 		})
 
 		It("skips malformed or unreadable block metadata files", func() {


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Golangci-lint fails to install via script since their release artifacts changed.


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
