### PR TITLE
Update stackitcloud/cloud-provider to v0.36.0-ske-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 )
 
-replace k8s.io/cloud-provider => github.com/stackitcloud/cloud-provider v0.36.0-ske-1
+replace k8s.io/cloud-provider => github.com/stackitcloud/cloud-provider v0.36.0-ske-2
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stackitcloud/cloud-provider v0.36.0-ske-1 h1:CZaL+8FH1rOjPnlPkhmvfKUkIX2r3MFOjfACdV8iFeo=
-github.com/stackitcloud/cloud-provider v0.36.0-ske-1/go.mod h1:y/3sksoC0taJZR0PcAAYUqVyD6Jzu2X0lD4yCEPXPuI=
+github.com/stackitcloud/cloud-provider v0.36.0-ske-2 h1:OCDooD0twsMDdcGbcEEofRa6rsfED5MG9gKnRP7n2y0=
+github.com/stackitcloud/cloud-provider v0.36.0-ske-2/go.mod h1:y/3sksoC0taJZR0PcAAYUqVyD6Jzu2X0lD4yCEPXPuI=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0 h1:jQEb9gkehfp6VCP6TcYk7BI10cz4l0KM2L6hqYBH2QA=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0/go.mod h1:WU1hhxnjXw2EV7CYa1nlEvNpMiRY6CvmIOaHuL3pOaA=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.2 h1:hWtbUy0UOhw1cE1riCNjvtmbF3zDl717DIcpEEMF9ps=


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/cherry-pick release-v1.36

**What this PR does / why we need it**:

This version includes the critical update to k8s.io/cloud-provider to allow for NodeUpdates when Gardener nodes are `Terminating`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
