### PR TITLE
node-controller: support multi-nic

### DIFF
--- a/docs/cloud-controller-manager.md
+++ b/docs/cloud-controller-manager.md
@@ -1,0 +1,19 @@
+# Cloud controller manager
+
+## Overview
+
+The cloud controller manager implements the [Kubernetes cloud-controller-manager contract](https://kubernetes.io/docs/concepts/architecture/cloud-controller/#functions-of-the-ccm).
+
+### Node controller
+
+#### Multi Network
+
+If a server has NICs connected to multiple networks, you can designate the primary network for Node Addresses by setting the default network in the config:
+
+```yaml
+instance:
+  # either network name or id
+  defaultNetwork: "foo"
+```
+
+This ensures the IP address for that network's NIC is listed first in the node status.

--- a/docs/cloud-controller-manager.md
+++ b/docs/cloud-controller-manager.md
@@ -6,9 +6,13 @@ The cloud controller manager implements the [Kubernetes cloud-controller-manager
 
 ### Node controller
 
+The node controller is responsible for updating Node objects when new servers are created in STACKIT infrastructure by obtaining information about the servers.
+
+For more information check the [Kubernetes documentation](https://kubernetes.io/docs/concepts/architecture/cloud-controller/#node-controller).
+
 #### Multi Network
 
-If a server has NICs connected to multiple networks, you can designate the primary network for Node Addresses by setting the default network in the config:
+If a server has NICs connected to multiple networks, you can designate the primary network for [Node Addresses](https://kubernetes.io/docs/reference/node/node-status/#addresses) by setting the default network in the config:
 
 ```yaml
 instance:
@@ -16,4 +20,4 @@ instance:
   defaultNetwork: "foo"
 ```
 
-This ensures the IP address for that network's NIC is listed first in the node status.
+This ensures the IP address for that network's NIC is listed first in the [Node status](https://kubernetes.io/docs/reference/node/node-status/#addresses).

--- a/docs/migration/configuration.md
+++ b/docs/migration/configuration.md
@@ -79,6 +79,8 @@ loadBalancer:
   extraLabels:
     key1: value1
     key2: value2
+instance: {}
+  # defaultNetwork: # used for multi-network nodes
 ```
 
 ### CSI Configuration

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -158,8 +158,8 @@ func (i *Instances) makeInstanceID(server *iaas.Server) string {
 }
 
 // sortNics sorts a slice of server network interfaces alphabetically by their network name
-// to ensure a deterministic order. If a non-empty defaultNetwork is provided (matching either 
-// the NetworkName or NetworkId), that specific network interface is moved to the front (index 0) 
+// to ensure a deterministic order. If a non-empty defaultNetwork is provided (matching either
+// the NetworkName or NetworkId), that specific network interface is moved to the front (index 0)
 // of the returned slice.
 func sortNics(nics []iaas.ServerNetwork, defaultNetwork string) []iaas.ServerNetwork {
 	// nics are returned by IaaS API in a non-deterministic order

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -157,6 +157,10 @@ func (i *Instances) makeInstanceID(server *iaas.Server) string {
 	return fmt.Sprintf("%s://%s", ProviderName, server.GetId())
 }
 
+// sortNics sorts a slice of server network interfaces alphabetically by their network name
+// to ensure a deterministic order. If a non-empty defaultNetwork is provided (matching either 
+// the NetworkName or NetworkId), that specific network interface is moved to the front (index 0) 
+// of the returned slice.
 func sortNics(nics []iaas.ServerNetwork, defaultNetwork string) []iaas.ServerNetwork {
 	// nics are returned by IaaS API in a non-deterministic order
 	// Sort by network name so that every time we use the same order for node addresses

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -173,6 +173,7 @@ func sortNics(nics []iaas.ServerNetwork, defaultNetwork string) []iaas.ServerNet
 	})
 	// network not found
 	if idx == -1 {
+		klog.Infof("no NIC found for default network %s", defaultNetwork)
 		return nics
 	}
 	defaultNic := nics[idx]

--- a/pkg/ccm/instances.go
+++ b/pkg/ccm/instances.go
@@ -21,10 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/labels"
 	stackitclient "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/client"
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/stackiterrors"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	corev1 "k8s.io/api/core/v1"
@@ -49,13 +51,15 @@ type Instances struct {
 	regionProviderID bool
 	iaasClient       stackitclient.IaaSClient
 	region           string
+	defaultNetwork   string
 }
 
-func NewInstance(client stackitclient.IaaSClient, region string) (*Instances, error) {
+func NewInstance(client stackitclient.IaaSClient, region string, opts config.InstanceOpts) (*Instances, error) {
 	return &Instances{
 		iaasClient:       client,
 		region:           region,
 		regionProviderID: false,
+		defaultNetwork:   opts.DefaultNetwork,
 	}, nil
 }
 
@@ -104,7 +108,7 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *corev1.Node) (*c
 		return nil, fmt.Errorf("server has no network interfaces")
 	}
 
-	nics := server.GetNics()
+	nics := sortNics(server.GetNics(), i.defaultNetwork)
 	for i := range nics {
 		nic := &nics[i]
 		if nic.HasIpv4() {
@@ -151,6 +155,31 @@ func (i *Instances) InstanceMetadata(ctx context.Context, node *corev1.Node) (*c
 
 func (i *Instances) makeInstanceID(server *iaas.Server) string {
 	return fmt.Sprintf("%s://%s", ProviderName, server.GetId())
+}
+
+func sortNics(nics []iaas.ServerNetwork, defaultNetwork string) []iaas.ServerNetwork {
+	// nics are returned by IaaS API in a non-deterministic order
+	// Sort by network name so that every time we use the same order for node addresses
+	slices.SortFunc(nics, func(a, b iaas.ServerNetwork) int {
+		return strings.Compare(a.NetworkName, b.NetworkName)
+	})
+
+	if defaultNetwork == "" {
+		return nics
+	}
+
+	idx := slices.IndexFunc(nics, func(nic iaas.ServerNetwork) bool {
+		return nic.NetworkName == defaultNetwork || nic.NetworkId == defaultNetwork
+	})
+	// network not found
+	if idx == -1 {
+		return nics
+	}
+	defaultNic := nics[idx]
+	nics = slices.Delete(nics, idx, idx+1)
+	// prepend default nic
+	nics = slices.Insert(nics, 0, defaultNic)
+	return nics
 }
 
 // addToNodeAddresses appends the NodeAddresses to the passed-by-pointer slice,

--- a/pkg/ccm/instances_test.go
+++ b/pkg/ccm/instances_test.go
@@ -26,6 +26,7 @@ import (
 	oapiError "github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 
 	stackitclientmock "github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/client/mock"
+	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/config"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +50,7 @@ var _ = Describe("Node Controller", func() {
 		nodeMockClient = stackitclientmock.NewMockIaaSClient(ctrl)
 
 		var err error
-		instance, err = NewInstance(nodeMockClient, "eu01")
+		instance, err = NewInstance(nodeMockClient, "eu01", config.InstanceOpts{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -279,6 +280,39 @@ var _ = Describe("Node Controller", func() {
 			metadata, err := instance.InstanceMetadata(context.Background(), node)
 			Expect(err).To(HaveOccurred())
 			Expect(metadata).To(BeNil())
+		})
+	})
+
+	Describe("#sortNics", func() {
+		It("should return the nic of the default network as primary", func() {
+			nics := []iaas.ServerNetwork{
+				{
+					NetworkName: "abc",
+					Ipv4:        new("10.0.0.69"),
+				},
+				{
+					NetworkName: "default",
+					Ipv4:        new("192.168.0.123"),
+				},
+				{
+					NetworkName: "foo",
+					NetworkId:   "123",
+					Ipv4:        new("100.80.0.5"),
+				},
+			}
+			By("with network name")
+			newNics := sortNics(nics, "default")
+			Expect(newNics).To(HaveLen(3))
+			Expect(newNics[0].NetworkName).To(Equal("default"))
+			Expect(newNics[1].NetworkName).To(Equal("abc"))
+			Expect(newNics[2].NetworkName).To(Equal("foo"))
+
+			By("with network id")
+			newNics = sortNics(nics, "123")
+			Expect(newNics).To(HaveLen(3))
+			Expect(newNics[0].NetworkName).To(Equal("foo"))
+			Expect(newNics[1].NetworkName).To(Equal("abc"))
+			Expect(newNics[2].NetworkName).To(Equal("default"))
 		})
 	})
 })

--- a/pkg/ccm/instances_test.go
+++ b/pkg/ccm/instances_test.go
@@ -288,10 +288,12 @@ var _ = Describe("Node Controller", func() {
 			nics := []iaas.ServerNetwork{
 				{
 					NetworkName: "abc",
+					NetworkId:   "69",
 					Ipv4:        new("10.0.0.69"),
 				},
 				{
 					NetworkName: "default",
+					NetworkId:   "69",
 					Ipv4:        new("192.168.0.123"),
 				},
 				{
@@ -310,9 +312,9 @@ var _ = Describe("Node Controller", func() {
 			By("with network id")
 			newNics = sortNics(nics, "123")
 			Expect(newNics).To(HaveLen(3))
-			Expect(newNics[0].NetworkName).To(Equal("foo"))
-			Expect(newNics[1].NetworkName).To(Equal("abc"))
-			Expect(newNics[2].NetworkName).To(Equal("default"))
+			Expect(newNics[0].NetworkId).To(Equal("123"))
+			Expect(newNics[1].NetworkId).To(Equal("69"))
+			Expect(newNics[2].NetworkId).To(Equal("69"))
 		})
 	})
 })

--- a/pkg/ccm/stackit.go
+++ b/pkg/ccm/stackit.go
@@ -151,7 +151,7 @@ func NewCloudControllerManager(cfg *stackitconfig.CCMConfig, obs *MetricsRemoteW
 		return nil, fmt.Errorf("failed to create IaaS client: %v", err)
 	}
 
-	instances, err := NewInstance(iaasClient, cfg.Global.Region)
+	instances, err := NewInstance(iaasClient, cfg.Global.Region, cfg.Instance)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stackit/config/config.go
+++ b/pkg/stackit/config/config.go
@@ -19,6 +19,14 @@ type CCMConfig struct {
 	Global       GlobalOpts       `yaml:"global"`
 	Metadata     metadata.Opts    `yaml:"metadata"`
 	LoadBalancer LoadBalancerOpts `yaml:"loadBalancer"`
+	Instance     InstanceOpts     `yaml:"instance"`
+}
+
+type InstanceOpts struct {
+	// DefaultNetwork contains the default network to use for a node.
+	// It can contain either the network name or ID.
+	// Can be used in mulit-network scenario to indicate which NIC is the primary one.
+	DefaultNetwork string `yaml:"defaultNetwork"`
 }
 
 type LoadBalancerOpts struct {


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement


**What this PR does / why we need it**:
Nodes with multiple NICs attached report in a non-deterministic way which IP to use as the primary one since the NICs of a server are returned in non-deterministic order from the Iaas API.

This PR ensures to always sort the returned NICs as well as having the option to specify a defaultNetwork, which when set, reports the NIC of the network on index 0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
