### PR TITLE
ci: add new category for kind/upgrade

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -12,6 +12,9 @@ changelog:
   - title: 🐛 Bug Fixes
     labels:
     - kind/bug
+  - title: 🚀 Dependency Updates
+    labels:
+    - kind/upgrade
   - title: ℹ️ Other Changes
     labels:
     - "*"


### PR DESCRIPTION
**How to categorize this PR?**

Adds a new category `Dependency Updates` for the release-job. This should make it a bit more cleaner and organized.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
