### PR TITLE
ci: remove k8s 1.33 support

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,6 @@
     'release-v1.36',
     'release-v1.35',
     'release-v1.34',
-    'release-v1.33',
   ],
   customManagers: [
     {
@@ -103,16 +102,6 @@
         'release-v1.34',
       ],
       allowedVersions: '<0.35.0',
-      automerge: false,
-    },
-    {
-      matchPackageNames: [
-        '/^k8s.io/',
-      ],
-      matchBaseBranches: [
-        'release-v1.33',
-      ],
-      allowedVersions: '<0.34.0',
       automerge: false,
     },
     {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The minor versions of `cloud-provider-stackit` are specifically aligned with the
 
 **Currently Supported Kubernetes Versions:**
 
-* `v1.33.x`
 * `v1.34.x`
 * `v1.35.x`
 * `v1.36.x`

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -15,7 +15,7 @@ APKO_VERSION ?= v1.2.25
 # renovate: datasource=github-releases depName=ko-build/ko
 KO_VERSION ?= v0.19.1
 
-KUBERNETES_TEST_VERSION ?= v1.33.5
+KUBERNETES_TEST_VERSION ?= v1.36.2
 
 # Tool targets should declare go.mod as a prerequisite, if the tool's version is managed via go modules. This causes
 # make to rebuild the tool in the desired version, when go.mod is changed.


### PR DESCRIPTION
**How to categorize this PR?**

/kind clean-up

**What this PR does / why we need it**:

Removes renovate auto-updates for k8s 1.33

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
