### PR TITLE
Bump apko dependencies; Check for valid `fsType` & enable `xfs` test in the e2e test

### DIFF
--- a/cmd/stackit-csi-plugin/apko-base-image.yaml
+++ b/cmd/stackit-csi-plugin/apko-base-image.yaml
@@ -6,20 +6,20 @@ contents:
   packages:
   - busybox # required by fsck.xfs as it is a sh script
   - ca-certificates
-  - blkid=~2.41.2
-  - blockdev=~2.41.2
+  - blkid=~2.41.3
+  - blockdev=~2.41.3
   - e2fsprogs=~1.47.3
   - e2fsprogs-extra=~1.47.3
-  - lsblk=~2.41.2
-  - mount=~2.41.2
-  - umount=~2.41.2
+  - lsblk=~2.41.3
+  - mount=~2.41.3
+  - umount=~2.41.3
   - btrfs-progs=~6.17
-  - udev=~258.1
-  - util-linux-misc=~2.41.2 # contains fsck
-  - xfsprogs=~6.17.0
-  - xfsprogs-core=~6.17.0
-  - xfsprogs-extra=~6.17.0 # contains xfs_io
-  - findmnt=~2.41.2
+  - udev=~259.1
+  - util-linux-misc=~2.41.3 # contains fsck
+  - xfsprogs=~6.18.0
+  - xfsprogs-core=~6.18.0
+  - xfsprogs-extra=~6.18.0 # contains xfs_io
+  - findmnt=~2.41.3
 
 accounts:
   run-as: root

--- a/cmd/stackit-csi-plugin/apko-base-image.yaml
+++ b/cmd/stackit-csi-plugin/apko-base-image.yaml
@@ -8,6 +8,7 @@ contents:
   - ca-certificates
   - blkid=~2.42.2
   - blockdev=~2.42.2
+  - btrfs-progs=~7.1
   - e2fsprogs=~1.47.4
   - e2fsprogs-extra=~1.47.4
   - lsblk=~2.42.2

--- a/cmd/stackit-csi-plugin/apko-base-image.yaml
+++ b/cmd/stackit-csi-plugin/apko-base-image.yaml
@@ -6,20 +6,19 @@ contents:
   packages:
   - busybox # required by fsck.xfs as it is a sh script
   - ca-certificates
-  - blkid=~2.41.3
-  - blockdev=~2.41.3
-  - e2fsprogs=~1.47.3
-  - e2fsprogs-extra=~1.47.3
-  - lsblk=~2.41.3
-  - mount=~2.41.3
-  - umount=~2.41.3
-  - btrfs-progs=~6.17
-  - udev=~259.1
-  - util-linux-misc=~2.41.3 # contains fsck
-  - xfsprogs=~6.18.0
-  - xfsprogs-core=~6.18.0
-  - xfsprogs-extra=~6.18.0 # contains xfs_io
-  - findmnt=~2.41.3
+  - blkid=~2.42.2
+  - blockdev=~2.42.2
+  - e2fsprogs=~1.47.4
+  - e2fsprogs-extra=~1.47.4
+  - lsblk=~2.42.2
+  - mount=~2.42.2
+  - umount=~2.42.2
+  - udev=~261.2
+  - util-linux-misc=~2.42.2 # contains fsck
+  - xfsprogs=~7.1.1
+  - xfsprogs-core=~7.1.1
+  - xfsprogs-extra=~7.1.1 # contains xfs_io
+  - findmnt=~2.42.2
 
 accounts:
   run-as: root

--- a/docs/csi-driver.md
+++ b/docs/csi-driver.md
@@ -27,6 +27,14 @@ The CSI driver enables dynamic provisioning and management of persistent volumes
 
 ## Basic Usage
 
+### Supported Filesystems
+
+We currently support the following file systems:
+
+- ext4
+- xfs
+- [EXPERIMENTAL] btrfs. Use at your own risk!
+
 ### Create a StorageClass
 
 ```YAML

--- a/docs/csi-driver.md
+++ b/docs/csi-driver.md
@@ -31,7 +31,8 @@ The CSI driver enables dynamic provisioning and management of persistent volumes
 
 We currently support the following file systems:
 
-- ext4
+- ext3
+- ext4 (default)
 - xfs
 - [EXPERIMENTAL] btrfs. Use at your own risk!
 

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -41,6 +41,7 @@ import (
 
 var (
 	ValidFSTypes = map[string]struct{}{
+		util.FSTypeExt3:  {},
 		util.FSTypeExt4:  {},
 		util.FSTypeXfs:   {},
 		util.FSTypeBtrfs: {},

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -277,7 +277,7 @@ func (ns *nodeServer) formatAndMountRetry(devicePath, stagingTarget, fsType stri
 	if fsType == util.FSTypeXfs {
 		// With newer xfsProgs version newer features are enabled by default. This forces mkfs.xfs to use flags compatible
 		// with the linux LTS 5.10 kernel
-		formatOptions := []string{"-i", "/usr/share/xfsprogs/mkfs/lts_5.10.conf"}
+		formatOptions := []string{"-n", "parent=0", "-i", "exchange=0"}
 		err = m.Mounter().FormatAndMountSensitiveWithFormatOptions(devicePath, stagingTarget, fsType, options, nil, formatOptions)
 	} else {
 		err = m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -206,7 +206,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	// Volume Mount
 	if notMnt {
 		// set default fstype is ext4
-		fsType := "ext4"
+		fsType := util.FSTypeExt4
 		var options []string
 		if mnt := volumeCapability.GetMount(); mnt != nil {
 			if mnt.FsType != "" {
@@ -274,7 +274,7 @@ func validateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) (stagingTar
 func (ns *nodeServer) formatAndMountRetry(devicePath, stagingTarget, fsType string, options []string) error {
 	m := ns.Mount
 	var err error
-	if fsType == "xfs" {
+	if fsType == util.FSTypeXfs {
 		// With newer xfsProgs version newer features are enabled by default. This forces mkfs.xfs to use flags compatible
 		// with the linux LTS 5.10 kernel
 		formatOptions := []string{"-i", "/usr/share/xfsprogs/mkfs/lts_5.10.conf"}
@@ -516,7 +516,7 @@ func collectMountOptions(fsType string, mntFlags []string) []string {
 
 	// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
 	// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
-	if fsType == "xfs" {
+	if fsType == util.FSTypeXfs {
 		options = append(options, "nouuid")
 	}
 	return options

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -41,8 +41,9 @@ import (
 
 var (
 	ValidFSTypes = map[string]struct{}{
-		util.FSTypeExt4: {},
-		util.FSTypeXfs:  {},
+		util.FSTypeExt4:  {},
+		util.FSTypeXfs:   {},
+		util.FSTypeBtrfs: {},
 	}
 )
 

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -39,6 +39,13 @@ import (
 	"github.com/stackitcloud/cloud-provider-stackit/pkg/stackit/metadata"
 )
 
+var (
+	ValidFSTypes = map[string]struct{}{
+		util.FSTypeExt4: {},
+		util.FSTypeXfs:  {},
+	}
+)
+
 type nodeServer struct {
 	Driver   *Driver
 	Mount    mount.IMount
@@ -205,6 +212,12 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			if mnt.FsType != "" {
 				fsType = mnt.FsType
 			}
+
+			_, ok := ValidFSTypes[strings.ToLower(fsType)]
+			if !ok {
+				return nil, status.Errorf(codes.InvalidArgument, "NodeStageVolume: invalid fstype %s. Only supported fsTypes are xfs or ext4 (default)", fsType)
+			}
+
 			mountFlags := mnt.GetMountFlags()
 			options = append(options, collectMountOptions(fsType, mountFlags)...)
 		}
@@ -260,7 +273,15 @@ func validateNodeStageVolumeRequest(req *csi.NodeStageVolumeRequest) (stagingTar
 // If the initial mount fails, it rescans the device and retries the mount operation.
 func (ns *nodeServer) formatAndMountRetry(devicePath, stagingTarget, fsType string, options []string) error {
 	m := ns.Mount
-	err := m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)
+	var err error
+	if fsType == "xfs" {
+		// With newer xfsProgs version newer features are enabled by default. This forces mkfs.xfs to use flags compatible
+		// with the linux LTS 5.10 kernel
+		formatOptions := []string{"-i", "/usr/share/xfsprogs/mkfs/lts_5.10.conf"}
+		err = m.Mounter().FormatAndMountSensitiveWithFormatOptions(devicePath, stagingTarget, fsType, options, nil, formatOptions)
+	} else {
+		err = m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)
+	}
 	if err != nil {
 		klog.Infof("Initial format and mount failed: %v. Attempting rescan.", err)
 		// Attempting rescan if the initial mount fails

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -277,7 +277,7 @@ func (ns *nodeServer) formatAndMountRetry(devicePath, stagingTarget, fsType stri
 	if fsType == util.FSTypeXfs {
 		// With newer xfsProgs version newer features are enabled by default. This forces mkfs.xfs to use flags compatible
 		// with the linux LTS 5.10 kernel
-		formatOptions := []string{"-n", "parent=0", "-i", "exchange=0"}
+		formatOptions := []string{"-n", "parent=0", "-i", "exchange=0,nrext64=0"}
 		err = m.Mounter().FormatAndMountSensitiveWithFormatOptions(devicePath, stagingTarget, fsType, options, nil, formatOptions)
 	} else {
 		err = m.Mounter().FormatAndMount(devicePath, stagingTarget, fsType, options)

--- a/pkg/csi/util/util.go
+++ b/pkg/csi/util/util.go
@@ -8,6 +8,11 @@ const (
 	TEBIBYTE
 )
 
+const (
+	FSTypeExt4 = "ext4"
+	FSTypeXfs  = "xfs"
+)
+
 // RoundUpSize calculates how many allocation units are needed to accommodate
 // a volume of given size. E.g. when user wants 1500MiB volume, while AWS EBS
 // allocates volumes in gibibyte-sized chunks,

--- a/pkg/csi/util/util.go
+++ b/pkg/csi/util/util.go
@@ -9,8 +9,9 @@ const (
 )
 
 const (
-	FSTypeExt4 = "ext4"
-	FSTypeXfs  = "xfs"
+	FSTypeExt4  = "ext4"
+	FSTypeXfs   = "xfs"
+	FSTypeBtrfs = "btrfs"
 )
 
 // RoundUpSize calculates how many allocation units are needed to accommodate

--- a/pkg/csi/util/util.go
+++ b/pkg/csi/util/util.go
@@ -9,6 +9,7 @@ const (
 )
 
 const (
+	FSTypeExt3  = "ext3"
 	FSTypeExt4  = "ext4"
 	FSTypeXfs   = "xfs"
 	FSTypeBtrfs = "btrfs"

--- a/test/e2e/csi-plugin/block-storage.yaml
+++ b/test/e2e/csi-plugin/block-storage.yaml
@@ -4,6 +4,9 @@ SnapshotClass:
   FromExistingClassName: "stackit"
 DriverInfo:
   Name: block-storage.csi.stackit.cloud
+  SupportedFsType:
+    ext4: {}
+    xfs: {}
   Capabilities:
     # whether to support RAW block mode
     block: true

--- a/test/e2e/csi-plugin/block-storage.yaml
+++ b/test/e2e/csi-plugin/block-storage.yaml
@@ -7,7 +7,6 @@ DriverInfo:
   SupportedFsType:
     ext4: {}
     xfs: {}
-    btrfs: {}
     ext3: {}
   Capabilities:
     # whether to support RAW block mode

--- a/test/e2e/csi-plugin/block-storage.yaml
+++ b/test/e2e/csi-plugin/block-storage.yaml
@@ -7,6 +7,8 @@ DriverInfo:
   SupportedFsType:
     ext4: {}
     xfs: {}
+    btrfs: {}
+    ext3: {}
   Capabilities:
     # whether to support RAW block mode
     block: true


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug
/cc @stackitcloud/ske-infrastructure 
/hold
This needs to be tested, we had issues with updates in the past see #549

**What this PR does / why we need it**:

* Updated all dependencies to latest
* Add check for valid `fsType`
* Configured CI e2e test to also test `fsType=xfs`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
