### PR TITLE
Make drivername configureable via go buildflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build: $(BUILD_IMAGES)
 $(BUILD_IMAGES): $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GOPROXY=${GOPROXY} go build \
 		-trimpath \
-		-ldflags $(LDFLAGS) \
+		-ldflags "$(LDFLAGS)" \
 		-o $@ \
 		cmd/$@/main.go
 
@@ -45,6 +45,10 @@ image-%: $(APKO) $(KO)
 	REPO=$(REPO)/$* \
 	IS_DEV=$(IS_DEV) \
 	./hack/build.sh $*
+
+.PHONY: image-stackit-csi-plugin-test
+image-stackit-csi-plugin-test: export KO_CONFIG_PATH = test/e2e/.ko-kubetest2.yaml
+image-stackit-csi-plugin-test: image-stackit-csi-plugin
 
 .PHONY: clean-tools-bin
 clean-tools-bin: ## Empty the tools binary directory.

--- a/pkg/csi/blockstorage/controllerserver.go
+++ b/pkg/csi/blockstorage/controllerserver.go
@@ -58,9 +58,8 @@ type stackitParameterConfig struct {
 }
 
 const (
-	blockStorageCSIClusterIDKey = "block-storage.csi.stackit.cloud/cluster"
-	snapshotTypeSnapshot        = "snapshot"
-	snapshotTypeBackup          = "backup"
+	snapshotTypeSnapshot = "snapshot"
+	snapshotTypeBackup   = "backup"
 )
 
 func (cs *controllerServer) validateVolumeCapabilities(req []*csi.VolumeCapability) error {
@@ -117,11 +116,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		accessibleTopologyReq := req.GetAccessibilityRequirements()
 		// Check from topology
 		if accessibleTopologyReq != nil {
-			if cs.Driver.legacyDriver {
-				volAvailability = sharedcsi.GetAZFromTopology(legacyTopologyKey, accessibleTopologyReq)
-			} else {
-				volAvailability = sharedcsi.GetAZFromTopology(topologyKey, accessibleTopologyReq)
-			}
+			volAvailability = sharedcsi.GetAZFromTopology(activeTopologyKey(cs.Driver.legacyDriver), accessibleTopologyReq)
 		}
 	}
 
@@ -148,7 +143,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	// Volume Create
 	// TODO: Use once IaaS has extended the label regex to allow for forward slashes and dots
-	// properties := map[string]string{blockStorageCSIClusterIDKey: cs.Driver.clusterID}
+	// properties := map[string]string{driverClusterIDKey(): cs.Driver.clusterID}
 	properties := map[string]string{}
 	// Tag volume with metadata if present: https://github.com/kubernetes-csi/external-provisioner/pull/399
 	for _, mKey := range sharedcsi.RecognizedCSIProvisionerParams {
@@ -678,7 +673,7 @@ func (cs *controllerServer) createSnapshot(ctx context.Context, name, volumeID s
 
 	// Add cluster ID to the snapshot metadata
 	// TODO: Use once IaaS has extended the label regex to allow for forward slashes and dots
-	// properties := map[string]string{blockStorageCSIClusterIDKey: cs.Driver.clusterID}
+	// properties := map[string]string{driverClusterIDKey(): cs.Driver.clusterID}
 	properties := map[string]string{}
 
 	// see https://github.com/kubernetes-csi/external-snapshotter/pull/375/
@@ -711,7 +706,7 @@ func (cs *controllerServer) createSnapshot(ctx context.Context, name, volumeID s
 func (cs *controllerServer) createBackup(ctx context.Context, cloud stackitclient.IaaSClient, name, volumeID string, snap *iaas.Snapshot, parameters map[string]string) (*iaas.Backup, error) { //nolint:lll // looks weird when shortened
 	// Add cluster ID to the snapshot metadata
 	// TODO: Use once IaaS has extended the label regex to allow for forward slashes and dots
-	// properties := map[string]string{blockStorageCSIClusterIDKey: cs.Driver.clusterID}
+	// properties := map[string]string{driverClusterIDKey(): cs.Driver.clusterID}
 	properties := map[string]string{}
 
 	// see https://github.com/kubernetes-csi/external-snapshotter/pull/375/
@@ -1023,7 +1018,7 @@ func (cs *controllerServer) getCreateVolumeResponse(vol *iaas.Volume) *csi.Creat
 		volumeSourceType = stackitclient.VolumeSourceTypes(vol.Source.Type)
 		switch volumeSourceType {
 		case stackitclient.VolumeSource:
-			volCnx[ResizeRequired] = "true"
+			volCnx[driverResizeRequiredKey()] = "true"
 
 			volsrc = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Volume{
@@ -1033,7 +1028,7 @@ func (cs *controllerServer) getCreateVolumeResponse(vol *iaas.Volume) *csi.Creat
 				},
 			}
 		case stackitclient.BackupSource:
-			volCnx[ResizeRequired] = "true"
+			volCnx[driverResizeRequiredKey()] = "true"
 
 			volsrc = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Snapshot{
@@ -1043,7 +1038,7 @@ func (cs *controllerServer) getCreateVolumeResponse(vol *iaas.Volume) *csi.Creat
 				},
 			}
 		case stackitclient.SnapshotSource:
-			volCnx[ResizeRequired] = "true"
+			volCnx[driverResizeRequiredKey()] = "true"
 
 			volsrc = &csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Snapshot{
@@ -1055,14 +1050,9 @@ func (cs *controllerServer) getCreateVolumeResponse(vol *iaas.Volume) *csi.Creat
 		}
 	}
 
-	topoKey := topologyKey
-	if cs.Driver.legacyDriver {
-		topoKey = legacyTopologyKey
-	}
-
 	accessibleTopology := []*csi.Topology{
 		{
-			Segments: map[string]string{topoKey: vol.AvailabilityZone},
+			Segments: map[string]string{activeTopologyKey(cs.Driver.legacyDriver): vol.AvailabilityZone},
 		},
 	}
 

--- a/pkg/csi/blockstorage/controllerserver_test.go
+++ b/pkg/csi/blockstorage/controllerserver_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ControllerServer test", Ordered, func() {
 				},
 				AccessibilityRequirements: &csi.TopologyRequirement{
 					Requisite: []*csi.Topology{
-						{Segments: map[string]string{topologyKey: "zone-from-accessibility-reqs"}},
+						{Segments: map[string]string{activeTopologyKey(false): "zone-from-accessibility-reqs"}},
 					},
 				},
 			}
@@ -143,7 +143,7 @@ var _ = Describe("ControllerServer test", Ordered, func() {
 				},
 				AccessibilityRequirements: &csi.TopologyRequirement{
 					Requisite: []*csi.Topology{
-						{Segments: map[string]string{topologyKey: "zone-from-accessibility-reqs"}},
+						{Segments: map[string]string{activeTopologyKey(false): "zone-from-accessibility-reqs"}},
 					},
 				},
 			}
@@ -279,7 +279,7 @@ var _ = Describe("ControllerServer test", Ordered, func() {
 					AccessibilityRequirements: &csi.TopologyRequirement{
 						Requisite: []*csi.Topology{
 							{
-								Segments: map[string]string{topologyKey: "eu01"},
+								Segments: map[string]string{activeTopologyKey(false): "eu01"},
 							},
 						},
 					},
@@ -412,7 +412,7 @@ var _ = Describe("ControllerServer test", Ordered, func() {
 				}
 				req.AccessibilityRequirements = &csi.TopologyRequirement{
 					Requisite: []*csi.Topology{
-						{Segments: map[string]string{topologyKey: "some-other-zone"}},
+						{Segments: map[string]string{activeTopologyKey(false): "some-other-zone"}},
 					},
 				}
 

--- a/pkg/csi/blockstorage/driver.go
+++ b/pkg/csi/blockstorage/driver.go
@@ -15,20 +15,41 @@ import (
 )
 
 const (
-	driverName        = "block-storage.csi.stackit.cloud"
-	legacyDriverName  = "cinder.csi.openstack.org"
-	topologyKey       = "topology." + driverName + "/zone"
-	legacyTopologyKey = "topology." + legacyDriverName + "/zone"
-
-	// ResizeRequired parameter, if set to true, will trigger a resize on mount operation
-	ResizeRequired = driverName + "/resizeRequired"
+	legacyDriverName = "cinder.csi.openstack.org"
 )
 
 var (
+	// DriverName is the default CSI driver name and can be overridden at build time
+	// using `go build -ldflags "-X github.com/stackitcloud/cloud-provider-stackit/pkg/csi/blockstorage.DriverName=..."`.
+	DriverName = "block-storage.csi.stackit.cloud"
 	// CSI spec version
 	specVersion = "1.12.0"
 	Version     = "1.0.0"
 )
+
+func topologyKeyForDriver(name string) string {
+	return "topology." + name + "/zone"
+}
+
+func driverResizeRequiredKey() string {
+	return DriverName + "/resizeRequired"
+}
+
+func driverClusterIDKey() string {
+	return DriverName + "/cluster"
+}
+
+func activeDriverName(legacy bool) string {
+	if legacy {
+		return legacyDriverName
+	}
+
+	return DriverName
+}
+
+func activeTopologyKey(legacy bool) string {
+	return topologyKeyForDriver(activeDriverName(legacy))
+}
 
 type Driver struct {
 	name                string
@@ -61,16 +82,12 @@ type DriverOpts struct {
 
 func NewDriver(o *DriverOpts) *Driver {
 	d := &Driver{
-		name:      driverName,
-		fqVersion: fmt.Sprintf("%s@%s", Version, version.Version),
-		endpoint:  o.Endpoint,
-		clusterID: o.ClusterID,
-		pvcLister: o.PVCLister,
-	}
-
-	if o.LegacyDriverName {
-		d.name = legacyDriverName
-		d.legacyDriver = true
+		name:         activeDriverName(o.LegacyDriverName),
+		fqVersion:    fmt.Sprintf("%s@%s", Version, version.Version),
+		endpoint:     o.Endpoint,
+		clusterID:    o.ClusterID,
+		legacyDriver: o.LegacyDriverName,
+		pvcLister:    o.PVCLister,
 	}
 
 	if o.BlockVolumeCreation {

--- a/pkg/csi/blockstorage/driver_name_test.go
+++ b/pkg/csi/blockstorage/driver_name_test.go
@@ -1,0 +1,28 @@
+package blockstorage
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Driver scoped keys", func() {
+	var originalDriverName string
+
+	BeforeEach(func() {
+		originalDriverName = DriverName
+		DriverName = "kubetest2.csi.stackit.cloud"
+	})
+
+	AfterEach(func() {
+		DriverName = originalDriverName
+	})
+
+	It("uses the active driver name and derived keys for the non-legacy driver", func() {
+		Expect(activeDriverName(false)).To(Equal("kubetest2.csi.stackit.cloud"))
+		Expect(activeDriverName(true)).To(Equal(legacyDriverName))
+		Expect(activeTopologyKey(false)).To(Equal("topology.kubetest2.csi.stackit.cloud/zone"))
+		Expect(activeTopologyKey(true)).To(Equal("topology.cinder.csi.openstack.org/zone"))
+		Expect(driverResizeRequiredKey()).To(Equal("kubetest2.csi.stackit.cloud/resizeRequired"))
+		Expect(driverClusterIDKey()).To(Equal("kubetest2.csi.stackit.cloud/cluster"))
+	})
+})

--- a/pkg/csi/blockstorage/nodeserver.go
+++ b/pkg/csi/blockstorage/nodeserver.go
@@ -230,7 +230,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		}
 	}
 
-	if required, ok := volumeContext[ResizeRequired]; ok && strings.EqualFold(required, "true") {
+	if required, ok := volumeContext[driverResizeRequiredKey()]; ok && strings.EqualFold(required, "true") {
 		r := mountutil.NewResizeFs(ns.Mount.Mounter().Exec)
 
 		needResize, err := r.NeedResize(devicePath, stagingTarget)
@@ -335,14 +335,9 @@ func (ns *nodeServer) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 		return nil, status.Errorf(codes.Internal, "[NodeGetInfo] Unable to retrieve availability zone of node %v", err)
 	}
 
-	topoKey := topologyKey
-	if ns.Driver.legacyDriver {
-		topoKey = legacyTopologyKey
-	}
-
 	//TODO: support well-known topology key "topology.kubernetes.io/zone"
 	segments := map[string]string{
-		topoKey: zone,
+		activeTopologyKey(ns.Driver.legacyDriver): zone,
 	}
 
 	nodeInfo.AccessibleTopology = &csi.Topology{Segments: segments}
@@ -357,13 +352,7 @@ func (ns *nodeServer) calculateMaxVolumesPerNode() int64 {
 		freePCIeRootPorts = 0
 	}
 
-	csiDriverName := driverName
-	if ns.Driver.legacyDriver {
-		// If driver launched in legacy-mode use "cinder.csi.openstack.org"
-		csiDriverName = legacyDriverName
-	}
-
-	mountedCSIVolumes, err := mount.CountLocalCSIVolumes(csiDriverName)
+	mountedCSIVolumes, err := mount.CountLocalCSIVolumes(activeDriverName(ns.Driver.legacyDriver))
 	if err != nil {
 		klog.Errorf("[NodeGetInfo] unable to retrieve volume count: %v", err)
 		mountedCSIVolumes = 0

--- a/test/e2e/.ko-kubetest2.yaml
+++ b/test/e2e/.ko-kubetest2.yaml
@@ -1,0 +1,7 @@
+builds:
+- id: stackit-csi-plugin
+  main: ./cmd/stackit-csi-plugin
+  ldflags:
+  - -s -w
+  - -X github.com/stackitcloud/cloud-provider-stackit/pkg/version.Version={{.Env.VERSION}}
+  - -X github.com/stackitcloud/cloud-provider-stackit/pkg/csi/blockstorage.DriverName=kubetest2.csi.stackit.cloud


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind test

**What this PR does / why we need it**:
In order to deploy the CSI driver alongside an existing CSI driver for end to end testing inside a running SKE cluster, we have to make the drivername configureable.

It should not be configureable via cli flag. Changing the driver name could break the installation, that shouldnt be exposed for production builds. It is only needed for testing so it can be configured via buildflags.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
