### PR TITLE
Fix unit tests aborting on bash 3.2

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -24,4 +24,4 @@ else
   timeout_flag="-timeout=2m"
 fi
 
-go test ${timeout_flag:+"$timeout_flag"} "$@" "${test_flags[@]}"
+go test ${timeout_flag:+"$timeout_flag"} "$@" ${test_flags[@]+"${test_flags[@]}"}


### PR DESCRIPTION
**How to categorize this PR?**

/kind bug

**What this PR does / why we need it**:

Script `hack/test.sh` sets `nounset` at line 4 and expands `test_flags` at line 27. Outside
CI that array is empty, and bash 3.2 treats the expansion of an empty array as an unbound
variable. Therefore `make verify` aborts before it runs a test:

```
./hack/test.sh ./cmd/... ./pkg/...
> Unit Tests
./hack/test.sh: line 27: test_flags[@]: unbound variable
make: *** [test] Error 1
```

macOS ships bash 3.2.57 as `/bin/bash`, so every contributor on a stock macOS machine hits
this at CONTRIBUTING step 4.

This PR guards the expansion, so it disappears when the array is empty. This matches the
`${timeout_flag:+...}` guard in the same line. Prow is not affected either way, because
there `CI` and `ARTIFACTS` are set and `test_flags` is never empty.

**Which issue(s) this PR fixes**:

Fixes #1504

**Special notes for your reviewer**:

The behavior of the guard on bash 3.2.57:

```
$ /bin/bash -c 'set -u; a=(); echo "before"; echo ${a[@]+"${a[@]}"}; echo "after"'
before

after
$ /bin/bash -c 'set -u; a=(one two); printf "[%s]\n" ${a[@]+"${a[@]}"}'
[one]
[two]
```

The second command shows that the elements stay separate arguments. The form uses `+` and
not `:+`, because the test must be "set" and not "set and not empty".

`make verify` passes on macOS 15.7.7, arm64, with bash 3.2.57.

**Breaking changes**:

None.
