### PR TITLE
CCM: Use existing metrics port (`--secure-port`) for SDK metrics instead of dedicated one (`--metrics-address`)

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/cloud-provider/options"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/component-base/metrics/legacyregistry"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	_ "k8s.io/component-base/metrics/prometheus/version"
 	"k8s.io/klog/v2"
@@ -32,6 +33,12 @@ const (
 var (
 	metricsAddressFlag *string
 )
+
+func init() {
+	// RawMustRegister is marked as deprecated because this bypasses the metric stability framework. But we want to
+	// use the same metrics in different repos, so it does not make sense to only use different types in this repo.
+	legacyregistry.RawMustRegister(metrics.NewExporter())
+}
 
 func main() {
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
@@ -49,8 +56,8 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	// setup metrics
-	metricsAddressFlag = additionalFlags.FlagSet("metrics").String("metrics-address", defaultMetricsAddress, "set the prometheus metrics endpoint")
+	// TODO: remove this later. Not removed yet because it is breaking to remove it.
+	metricsAddressFlag = additionalFlags.FlagSet("metrics").String("metrics-address", defaultMetricsAddress, "set the prometheus metrics endpoint.  Deprecated, do not use! Use --secure-port for metrics.")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer(ctx), controllerInitializers, controllerAliases, additionalFlags, wait.NeverStop)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)

--- a/deploy/cloud-controller-manager/deployment.yaml
+++ b/deploy/cloud-controller-manager/deployment.yaml
@@ -39,7 +39,6 @@ spec:
           value: /etc/serviceaccount/sa_key.json
         ports:
         - containerPort: 10258
-          hostPort: 10258
           name: https
           protocol: TCP
         resources:

--- a/deploy/cloud-controller-manager/deployment.yaml
+++ b/deploy/cloud-controller-manager/deployment.yaml
@@ -42,10 +42,6 @@ spec:
           hostPort: 10258
           name: https
           protocol: TCP
-        - containerPort: 9090
-          hostPort: 9090
-          name: metrics
-          protocol: TCP
         resources:
           limits:
             cpu: "0.5"

--- a/deploy/cloud-controller-manager/service.yaml
+++ b/deploy/cloud-controller-manager/service.yaml
@@ -9,12 +9,8 @@ spec:
   selector:
     app: stackit-cloud-controller-manager
   ports:
-  - name: main
-    port: 80
-    targetPort: 8888
-    protocol: TCP
-  - name: metrics
-    port: 8080
-    targetPort: metrics
+  - name: https
+    port: 10258
+    targetPort: https
     protocol: TCP
   type: ClusterIP


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
The CCM somehow has 2 metrics port. `--secure-port` which also contains some metrics from the cloud-provider package and `--metrics-address` which only contains the SDK metrics. 

This PR adds the SDK metrics to the metrics served with `--secure-port`. `--metrics-address` is still available and needs will be removed in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

We also could still open the `--metrics-address` for transition, instead of not using it directly.

**Breaking changes**:

<!--
If your PR contains breaking changes, list the changes in detail here.
This could be:
- removing a documented feature, that we need to announce properly
- a change of the configuration, that needs to be adopted in the provider-stackit

Additionally, add the breaking label for the release note generation via:
/label breaking
-->
