### PR TITLE
Tolerate uninitialized taint in CCM deployment

### DIFF
--- a/deploy/cloud-controller-manager/deployment.yaml
+++ b/deploy/cloud-controller-manager/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: stackit-cloud-controller-manager
     spec:
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+        effect: NoSchedule
       serviceAccountName: stackit-cloud-controller-manager
       terminationGracePeriodSeconds: 30
       containers:


### PR DESCRIPTION
**How to categorize this PR?**

/kind bug

**What this PR does / why we need it**:

Kubelet puts the taint `node.cloudprovider.kubernetes.io/uninitialized:NoSchedule` on each node when it runs with `--cloud-provider=external`. `deploy/cloud-controller-manager/deployment.yaml` has no `tolerations` block, so the scheduler cannot place the pod. On a new cluster all nodes have this taint, and the pod stays in the Pending condition. The report shows this message:

```
Warning  FailedScheduling  1s  default-scheduler  0/3 nodes are available: 3 node(s) had untolerated taint(s).
```

This pull request adds a toleration for this one taint. The operator `Exists` matches the taint with any value. The pod stays sensitive to all other taints. This is different from `deploy/csi-plugin/nodeplugin.yaml`, which tolerates each taint, because a node plugin must operate on every node.

**Which issue(s) this PR fixes**:
Part of #1162

The issue reports two defects. This pull request corrects the first one. The second defect is the image tag `release-v1.34`, which is not in the registry. That defect needs a decision from the maintainers, and it is not part of this pull request.

**Special notes for your reviewer**:

The deployment starts the CCM with `--controllers=service-lb-controller`. This flag keeps `cloud-node-controller` off, and `cloud-node-controller` is the controller that removes this taint. So this change lets the CCM start on a tainted node, but it does not remove the taint from the node.

`kubectl kustomize deploy/cloud-controller-manager` builds correctly, and the toleration is in the output. `make verify` gives 0 lint issues and all unit tests pass.

**Breaking changes**:

None.