### PR TITLE
Push releases additionally with a tag without the patch part of the version

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -44,10 +44,14 @@ if [[ -n "${PULL_NUMBER:=""}" ]]; then
   tags+=("pr-${PULL_NUMBER}")
 fi
 
-# tag for release builds
-# overwrite the tags, we don't need tags for branch or the date-commit_sha in released versions.
+# Tag for release builds
+# Overwrite the tags, we don't need tags for branch or the date-commit_sha in released versions.
 if git_tag="$(git describe --tags --exact-match 2>/dev/null)"; then
-  tags=("$git_tag" "${git_tag%.*}")
+  tags=("$git_tag")
+  # For clean semver tags we also add a tag without patch version. To have a "latest" for each k8s version.
+  if [[ $git_tag =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    tags+=("${git_tag%.*}")
+  fi
 fi
 
 if [[ ${IS_DEV} == "true" ]]; then

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -45,8 +45,9 @@ if [[ -n "${PULL_NUMBER:=""}" ]]; then
 fi
 
 # tag for release builds
+# overwrite the tags, we don't need tags for branch or the date-commit_sha in released versions.
 if git_tag="$(git describe --tags --exact-match 2>/dev/null)"; then
-  tags+=("$git_tag")
+  tags=("$git_tag" "${git_tag%.*}")
 fi
 
 if [[ ${IS_DEV} == "true" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

<!--
Once this PR is merged, Prow automatically creates cherry-pick PRs for the release branches specified below.
Keep only the release branches this change should be ported to.
-->

/cherry-pick release-v1.34
/cherry-pick release-v1.35
/cherry-pick release-v1.36

**What this PR does / why we need it**:
This adds an additionally tag without the patch part of the semver.
Additionally it overwrites the tags instead of append, in an release there is no branch (empty), we don't need a version with v<commit-timestamp>-<short-commit-sha> and the actual version was 2 times in the list.

**Which issue(s) this PR fixes**:
Part of #1162

**Special notes for your reviewer**:

To test you can checkout different tags/branches and run `make images` to check the tags.

