### PR TITLE
Use version tag without patch in deployment files

### DIFF
--- a/deploy/cloud-controller-manager/deployment.yaml
+++ b/deploy/cloud-controller-manager/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: stackit-cloud-controller-manager
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:release-v1.34
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/cloud-controller-manager:v1.36
         args:
         - "--cloud-provider=stackit"
         - "--webhook-secure-port=0"

--- a/deploy/csi-plugin/controllerplugin.yaml
+++ b/deploy/csi-plugin/controllerplugin.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: csi-stackit-controller-sa
       containers:
       - name: csi-attacher
-        image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
         args:
         - "--csi-address=$(ADDRESS)"
         - "--timeout=3m"
@@ -39,7 +39,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-provisioner
-        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
         args:
         - "--csi-address=$(ADDRESS)"
         - "--timeout=3m"
@@ -55,7 +55,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-snapshotter
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
         args:
         - "--csi-address=$(ADDRESS)"
         - "--timeout=3m"
@@ -69,7 +69,7 @@ spec:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - name: csi-resizer
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
         args:
         - "--csi-address=$(ADDRESS)"
         - "--timeout=3m"
@@ -83,7 +83,7 @@ spec:
         - name: socket-dir
           mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: liveness-probe
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         args:
         - "--csi-address=$(ADDRESS)"
         env:
@@ -93,7 +93,7 @@ spec:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - name: stackit-csi-plugin
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:release-v1.34
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:v1.36
         args:
         - /bin/stackit-csi-plugin
         - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/csi-plugin/nodeplugin.yaml
+++ b/deploy/csi-plugin/nodeplugin.yaml
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-driver-registrar
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
         args:
         - "--csi-address=$(ADDRESS)"
         - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -41,7 +41,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: liveness-probe
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
         args:
         - --csi-address=/csi/csi.sock
         volumeMounts:
@@ -53,7 +53,7 @@ spec:
           capabilities:
             add: ["SYS_ADMIN"]
           allowPrivilegeEscalation: true
-        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:release-v1.34
+        image: ghcr.io/stackitcloud/cloud-provider-stackit/stackit-csi-plugin:v1.36
         args:
         - /bin/stackit-csi-plugin
         - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement
/cc @stackitcloud/ske-infrastructure 

<!--
Once this PR is merged, Prow automatically creates cherry-pick PRs for the release branches specified below.
Keep only the release branches this change should be ported to.
-->

/cherry-pick release-v1.36

**What this PR does / why we need it**:
The current tag is not working. 

I also bumped all other versions to the same we use un gardener-extension-provider-stackit.
I will open separate PRs for `release-v1.35` and `release-v1.34` (release-v1.36 can be cherry-picked).

**Which issue(s) this PR fixes**:
Part of #1162


