### PR TITLE
Add step doumentation of new kubernetes version for deployment files

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -49,15 +49,16 @@ Publishing a new release triggers the same Prow release job that builds and publ
 ## Releasing a New Kubernetes Version
 
 1. Create a new version of the [`cloud-provider`](https://github.com/stackitcloud/cloud-provider) fork.
-  1. Create a new release branch `ske-v0.xx` from the latest patch version tag of the desired Kubernetes version.
-  2. Cherry-pick our changes into the release branch. Example: https://github.com/stackitcloud/cloud-provider/commits/ske-v0.35/
-  3. Tag the release branch with `v0.xx.x-ske-x`.
+    1. Create a new release branch `ske-v0.xx` from the latest patch version tag of the desired Kubernetes version.
+    2. Cherry-pick our changes into the release branch. Example: https://github.com/stackitcloud/cloud-provider/commits/ske-v0.35/
+    3. Tag the release branch with `v0.xx.x-ske-x`.
 2. Bump the Kubernetes packages, including an overwrite of the `cloud-provider` fork, in the `main` branch.
-3. Create a new release branch `release-v1.XX` from `main`.
-4. Update the Renovate configuration via a PR against `main`: add the new release branch to `baseBranchPatterns` and add a new rule in `packageRules` for `/^k8s.io/`. Cherry-pick this PR to all maintained release branches. Example PR: https://github.com/stackitcloud/cloud-provider-stackit/pull/756
-5. Create a manual release for the new branch (note: the release tool will only work if there is already a tag on the branch). Do not generate release notes as they will contain many unrelated changes. Just add `Initial release of v1.xx.0` as release notes.
-6. Add the new version in the `README.md`.
-7. Add the cherry-pick command (`/cherry-pick release-v1.XX`) for the new release branch to `.github/pull_request_template.md`.
+3. Bump the version used in the deployments ([/deploy](/deploy) folder) to the new version (w/o the patch version part)
+4. Create a new release branch `release-v1.XX` from `main`.
+5. Update the Renovate configuration via a PR against `main`: add the new release branch to `baseBranchPatterns` and add a new rule in `packageRules` for `/^k8s.io/`. Cherry-pick this PR to all maintained release branches. Example PR: https://github.com/stackitcloud/cloud-provider-stackit/pull/756
+6. Create a manual release for the new branch (note: the release tool will only work if there is already a tag on the branch). Do not generate release notes as they will contain many unrelated changes. Just add `Initial release of v1.xx.0` as release notes.
+7. Add the new version in the `README.md`.
+8. Add the cherry-pick command (`/cherry-pick release-v1.XX`) for the new release branch to `.github/pull_request_template.md`.
 
 ## Remove an Old Kubernetes Version
 


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement
/cc @stackitcloud/ske-infrastructure 

<!--
Once this PR is merged, Prow automatically creates cherry-pick PRs for the release branches specified below.
Keep only the release branches this change should be ported to.
-->

/cherry-pick release-v1.34
/cherry-pick release-v1.35
/cherry-pick release-v1.36

**What this PR does / why we need it**:
Add step to update the deploy files when adding a new k8s version.

I also fixed the indentation for the nested list. 
